### PR TITLE
Use User{Const}Ptr to enforce uspace adress pointer correctness

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,11 @@ extern crate axstd;
 mod ctypes;
 
 mod mm;
+mod ptr;
 mod syscall_imp;
 mod task;
-use alloc::{string::ToString, sync::Arc, vec};
 
+use alloc::{string::ToString, sync::Arc, vec};
 use axhal::arch::UspaceContext;
 use axstd::println;
 use axsync::Mutex;

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -1,0 +1,157 @@
+use axerrno::{LinuxError, LinuxResult};
+use axtask::{TaskExtRef, current};
+use memory_addr::{MemoryAddr, PAGE_SIZE_4K, PageIter4K, VirtAddr};
+
+use core::{alloc::Layout, ffi::c_char};
+
+fn check_region(start: VirtAddr, layout: Layout) -> LinuxResult<()> {
+    let align = layout.align();
+    if start.as_usize() & (align - 1) != 0 {
+        return Err(LinuxError::EFAULT);
+    }
+
+    // TODO: currently we're doing a very basic and inefficient check, due to
+    // the fact that AddrSpace does not expose necessary API.
+    let task = current();
+    let aspace = task.task_ext().aspace.lock();
+    let pt = aspace.page_table();
+
+    let page_start = start.align_down_4k();
+    let page_end = (start + layout.size()).align_up_4k();
+    for page in PageIter4K::new(page_start, page_end).unwrap() {
+        if pt.query(page).is_err() {
+            return Err(LinuxError::EFAULT);
+        }
+    }
+
+    Ok(())
+}
+
+fn check_cstr(start: VirtAddr) -> LinuxResult<()> {
+    // TODO: see check_region
+    let task = current();
+    let aspace = task.task_ext().aspace.lock();
+    let pt = aspace.page_table();
+
+    let mut it = start;
+    let mut page = it.align_down_4k();
+    if pt.query(page).is_err() {
+        return Err(LinuxError::EFAULT);
+    }
+    page += PAGE_SIZE_4K;
+    loop {
+        if unsafe { *it.as_ptr_of::<c_char>() } == 0 {
+            break;
+        }
+
+        it += 1;
+        if it == page {
+            if pt.query(page).is_err() {
+                return Err(LinuxError::EFAULT);
+            }
+            page += PAGE_SIZE_4K;
+        }
+    }
+
+    Ok(())
+}
+
+/// A trait representing a pointer in user space, which can be converted to a
+/// pointer in kernel space through a series of checks.
+///
+/// Converting a `PtrWrapper<T>` to `*T` is done by `PtrWrapper::get` (or
+/// `get_as_*`). It checks whether the pointer along with its layout is valid in
+/// the current task's address space, and raises EFAULT if not.
+pub trait PtrWrapper<T>: Sized {
+    type Ptr;
+
+    /// Unwrap the pointer to the inner type.
+    ///
+    /// This function is unsafe because it assumes that the pointer is valid and
+    /// points to a valid memory region.
+    unsafe fn into_inner(self) -> Self::Ptr;
+
+    /// Get the address of the pointer.
+    fn address(&self) -> VirtAddr;
+
+    /// Get the pointer as a raw pointer to `T`.
+    fn get(self) -> LinuxResult<Self::Ptr> {
+        self.get_as(Layout::new::<T>())
+    }
+
+    /// Get the pointer as a raw pointer to `T`, validating the memory
+    /// region given by the layout.
+    fn get_as(self, layout: Layout) -> LinuxResult<Self::Ptr> {
+        check_region(self.address(), layout)?;
+        unsafe { Ok(self.into_inner()) }
+    }
+
+    /// Get the pointer as a raw pointer to `T`, validating the memory
+    /// region specified by the size.
+    fn get_as_bytes(self, size: usize) -> LinuxResult<Self::Ptr> {
+        check_region(self.address(), Layout::from_size_align(size, 1).unwrap())?;
+        unsafe { Ok(self.into_inner()) }
+    }
+
+    /// Get the pointer as a raw pointer to `T`, validating the memory
+    /// region given by the layout of `[T; len]`.
+    fn get_as_array(self, len: usize) -> LinuxResult<Self::Ptr> {
+        check_region(self.address(), Layout::array::<T>(len).unwrap())?;
+        unsafe { Ok(self.into_inner()) }
+    }
+
+    /// Get the pointer as a raw pointer to `T`, validating the memory
+    /// region specified by the size of a C string.
+    fn get_as_cstr(self) -> LinuxResult<Self::Ptr> {
+        check_cstr(self.address())?;
+        unsafe { Ok(self.into_inner()) }
+    }
+}
+
+/// A pointer to user space memory.
+///
+/// See [`PtrWrapper`] for more details.
+#[repr(transparent)]
+pub struct UserPtr<T>(*mut T);
+
+impl<T> From<usize> for UserPtr<T> {
+    fn from(value: usize) -> Self {
+        UserPtr(value as *mut _)
+    }
+}
+
+impl<T> PtrWrapper<T> for UserPtr<T> {
+    type Ptr = *mut T;
+
+    unsafe fn into_inner(self) -> Self::Ptr {
+        self.0
+    }
+
+    fn address(&self) -> VirtAddr {
+        VirtAddr::from_mut_ptr_of(self.0)
+    }
+}
+
+/// An immutable pointer to user space memory.
+///
+/// See [`PtrWrapper`] for more details.
+#[repr(transparent)]
+pub struct UserConstPtr<T>(*const T);
+
+impl<T> From<usize> for UserConstPtr<T> {
+    fn from(value: usize) -> Self {
+        UserConstPtr(value as *const _)
+    }
+}
+
+impl<T> PtrWrapper<T> for UserConstPtr<T> {
+    type Ptr = *const T;
+
+    unsafe fn into_inner(self) -> Self::Ptr {
+        self.0
+    }
+
+    fn address(&self) -> VirtAddr {
+        VirtAddr::from_ptr_of(self.0)
+    }
+}

--- a/src/syscall_imp/fs/ctl.rs
+++ b/src/syscall_imp/fs/ctl.rs
@@ -2,7 +2,7 @@ use core::ffi::{c_char, c_int, c_void};
 
 use alloc::string::ToString;
 use arceos_posix_api::AT_FDCWD;
-use axerrno::AxError;
+use axerrno::{AxError, LinuxError};
 use axtask::{TaskExtRef, current};
 
 use crate::{
@@ -196,7 +196,7 @@ pub(crate) fn sys_getdents64(fd: i32, buf: UserPtr<c_void>, len: usize) -> isize
     };
 
     axfs::api::read_dir(&path)
-        .map_err(|_| -1)
+        .map_err(|_| LinuxError::EINVAL as isize)
         .map(|entries| {
             let mut total_size = initial_offset as usize;
             let mut current_offset = initial_offset;
@@ -230,7 +230,7 @@ pub(crate) fn sys_getdents64(fd: i32, buf: UserPtr<c_void>, len: usize) -> isize
 
             total_size as isize
         })
-        .unwrap_or(-1)
+        .unwrap_or(LinuxError::ENOENT as isize)
 }
 
 /// create a link from new_path to old_path

--- a/src/syscall_imp/fs/ctl.rs
+++ b/src/syscall_imp/fs/ctl.rs
@@ -2,10 +2,13 @@ use core::ffi::{c_char, c_int, c_void};
 
 use alloc::string::ToString;
 use arceos_posix_api::AT_FDCWD;
-use axerrno::{AxError, LinuxError};
+use axerrno::AxError;
 use axtask::{TaskExtRef, current};
 
-use crate::syscall_body;
+use crate::{
+    ptr::{PtrWrapper, UserConstPtr, UserPtr},
+    syscall_body, syscall_unwrap,
+};
 
 /// The ioctl() system call manipulates the underlying device parameters
 /// of special files.
@@ -15,14 +18,15 @@ use crate::syscall_body;
 /// * `op` - The request code. It is of type unsigned long in glibc and BSD,
 ///   and of type int in musl and other UNIX systems.
 /// * `argp` - The argument to the request. It is a pointer to a memory location
-pub(crate) fn sys_ioctl(_fd: i32, _op: usize, _argp: *mut c_void) -> i32 {
+pub(crate) fn sys_ioctl(_fd: i32, _op: usize, _argp: UserPtr<c_void>) -> i32 {
     syscall_body!(sys_ioctl, {
         warn!("Unimplemented syscall: SYS_IOCTL");
         Ok(0)
     })
 }
 
-pub(crate) fn sys_chdir(path: *const c_char) -> c_int {
+pub(crate) fn sys_chdir(path: UserConstPtr<c_char>) -> c_int {
+    let path = syscall_unwrap!(path.get_as_cstr());
     let path = match arceos_posix_api::char_ptr_to_str(path) {
         Ok(path) => path,
         Err(err) => {
@@ -39,7 +43,8 @@ pub(crate) fn sys_chdir(path: *const c_char) -> c_int {
         })
 }
 
-pub(crate) fn sys_mkdirat(dirfd: i32, path: *const c_char, mode: u32) -> c_int {
+pub(crate) fn sys_mkdirat(dirfd: i32, path: UserConstPtr<c_char>, mode: u32) -> c_int {
+    let path = syscall_unwrap!(path.get_as_cstr());
     let path = match arceos_posix_api::char_ptr_to_str(path) {
         Ok(path) => path,
         Err(err) => {
@@ -157,7 +162,9 @@ impl<'a> DirBuffer<'a> {
     }
 }
 
-pub(crate) fn sys_getdents64(fd: i32, buf: *mut c_void, len: usize) -> isize {
+pub(crate) fn sys_getdents64(fd: i32, buf: UserPtr<c_void>, len: usize) -> isize {
+    let buf = syscall_unwrap!(buf.get_as_bytes(len));
+
     if len < DirEnt::FIXED_SIZE {
         warn!("Buffer size too small: {len}");
         return -1;
@@ -202,7 +209,8 @@ pub(crate) fn sys_getdents64(fd: i32, buf: *mut c_void, len: usize) -> isize {
     };
 
     axfs::api::read_dir(&path)
-        .map(|entries| {
+        .map_err(|_| -1)
+        .and_then(|entries| {
             let mut total_size = initial_offset as usize;
             let mut current_offset = initial_offset;
 
@@ -232,9 +240,10 @@ pub(crate) fn sys_getdents64(fd: i32, buf: *mut c_void, len: usize) -> isize {
                 let terminal = DirEnt::new(1, current_offset, 0, FileType::Reg);
                 let _ = buffer.write_entry(terminal, &[]);
             }
-            total_size as isize
+
+            Ok(total_size as isize)
         })
-        .unwrap_or(LinuxError::ENOENT as isize)
+        .unwrap_or(-1)
 }
 
 /// create a link from new_path to old_path
@@ -244,21 +253,24 @@ pub(crate) fn sys_getdents64(fd: i32, buf: *mut c_void, len: usize) -> isize {
 /// return value: return 0 when success, else return -1.
 pub(crate) fn sys_linkat(
     old_dirfd: i32,
-    old_path: *const u8,
+    old_path: UserConstPtr<c_char>,
     new_dirfd: i32,
-    new_path: *const u8,
+    new_path: UserConstPtr<c_char>,
     flags: i32,
 ) -> i32 {
+    let old_path = syscall_unwrap!(old_path.get_as_cstr());
+    let new_path = syscall_unwrap!(new_path.get_as_cstr());
+
     if flags != 0 {
         warn!("Unsupported flags: {flags}");
     }
 
     // handle old path
-    arceos_posix_api::handle_file_path(old_dirfd as isize, Some(old_path), false)
+    arceos_posix_api::handle_file_path(old_dirfd as isize, Some(old_path as _), false)
         .inspect_err(|err| warn!("Failed to convert new path: {err:?}"))
         .and_then(|old_path| {
             //handle new path
-            arceos_posix_api::handle_file_path(new_dirfd as isize, Some(new_path), false)
+            arceos_posix_api::handle_file_path(new_dirfd as isize, Some(new_path as _), false)
                 .inspect_err(|err| warn!("Failed to convert new path: {err:?}"))
                 .map(|new_path| (old_path, new_path))
         })
@@ -277,10 +289,12 @@ pub(crate) fn sys_linkat(
 /// path: the name of link to be removed
 /// flags: can be 0 or AT_REMOVEDIR
 /// return 0 when success, else return -1
-pub fn sys_unlinkat(dir_fd: isize, path: *const u8, flags: usize) -> isize {
+pub fn sys_unlinkat(dir_fd: isize, path: UserConstPtr<c_char>, flags: usize) -> isize {
+    let path = syscall_unwrap!(path.get_as_cstr());
+
     const AT_REMOVEDIR: usize = 0x200;
 
-    arceos_posix_api::handle_file_path(dir_fd, Some(path), false)
+    arceos_posix_api::handle_file_path(dir_fd, Some(path as _), false)
         .inspect_err(|e| warn!("unlinkat error: {:?}", e))
         .and_then(|path| {
             if flags == AT_REMOVEDIR {
@@ -307,6 +321,6 @@ pub fn sys_unlinkat(dir_fd: isize, path: *const u8, flags: usize) -> isize {
         .unwrap_or(-1)
 }
 
-pub(crate) fn sys_getcwd(buf: *mut c_char, size: usize) -> *mut c_char {
-    arceos_posix_api::sys_getcwd(buf, size)
+pub(crate) fn sys_getcwd(buf: UserPtr<c_char>, size: usize) -> *mut c_char {
+    syscall_body!(sys_getcwd, Ok(arceos_posix_api::sys_getcwd(buf.get_as_cstr()?, size)))
 }

--- a/src/syscall_imp/fs/ctl.rs
+++ b/src/syscall_imp/fs/ctl.rs
@@ -197,7 +197,7 @@ pub(crate) fn sys_getdents64(fd: i32, buf: UserPtr<c_void>, len: usize) -> isize
 
     axfs::api::read_dir(&path)
         .map_err(|_| -1)
-        .and_then(|entries| {
+        .map(|entries| {
             let mut total_size = initial_offset as usize;
             let mut current_offset = initial_offset;
 
@@ -228,7 +228,7 @@ pub(crate) fn sys_getdents64(fd: i32, buf: UserPtr<c_void>, len: usize) -> isize
                 let _ = buffer.write_entry(terminal, &[]);
             }
 
-            Ok(total_size as isize)
+            total_size as isize
         })
         .unwrap_or(-1)
 }

--- a/src/syscall_imp/fs/io.rs
+++ b/src/syscall_imp/fs/io.rs
@@ -29,7 +29,7 @@ pub(crate) fn sys_openat(
     modes: mode_t,
 ) -> isize {
     let path = syscall_unwrap!(path.get_as_cstr());
-    api::sys_openat(dirfd, path, flags, modes) as _
+    api::sys_openat(dirfd, path.as_ptr(), flags, modes) as _
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/src/syscall_imp/fs/io.rs
+++ b/src/syscall_imp/fs/io.rs
@@ -2,24 +2,38 @@ use core::ffi::{c_char, c_void};
 
 use arceos_posix_api::{self as api, ctypes::mode_t};
 
-pub(crate) fn sys_read(fd: i32, buf: *mut c_void, count: usize) -> isize {
+use crate::{
+    ptr::{PtrWrapper, UserConstPtr, UserPtr},
+    syscall_unwrap,
+};
+
+pub(crate) fn sys_read(fd: i32, buf: UserPtr<c_void>, count: usize) -> isize {
+    let buf = syscall_unwrap!(buf.get_as_bytes(count));
     api::sys_read(fd, buf, count)
 }
 
-pub(crate) fn sys_write(fd: i32, buf: *const c_void, count: usize) -> isize {
+pub(crate) fn sys_write(fd: i32, buf: UserConstPtr<c_void>, count: usize) -> isize {
+    let buf = syscall_unwrap!(buf.get_as_bytes(count));
     api::sys_write(fd, buf, count)
 }
 
-pub(crate) fn sys_writev(fd: i32, iov: *const api::ctypes::iovec, iocnt: i32) -> isize {
+pub(crate) fn sys_writev(fd: i32, iov: UserConstPtr<api::ctypes::iovec>, iocnt: i32) -> isize {
+    let iov = syscall_unwrap!(iov.get_as_bytes(iocnt as _));
     unsafe { api::sys_writev(fd, iov, iocnt) }
 }
 
-pub(crate) fn sys_openat(dirfd: i32, path: *const c_char, flags: i32, modes: mode_t) -> isize {
-    api::sys_openat(dirfd, path, flags, modes) as isize
+pub(crate) fn sys_openat(
+    dirfd: i32,
+    path: UserConstPtr<c_char>,
+    flags: i32,
+    modes: mode_t,
+) -> isize {
+    let path = syscall_unwrap!(path.get_as_cstr());
+    api::sys_openat(dirfd, path, flags, modes) as _
 }
 
 #[cfg(target_arch = "x86_64")]
-pub(crate) fn sys_open(path: *const c_char, flags: i32, modes: mode_t) -> isize {
+pub(crate) fn sys_open(path: UserConstPtr<c_char>, flags: i32, modes: mode_t) -> isize {
     use arceos_posix_api::AT_FDCWD;
     sys_openat(AT_FDCWD as _, path, flags, modes)
 }

--- a/src/syscall_imp/fs/pipe.rs
+++ b/src/syscall_imp/fs/pipe.rs
@@ -2,7 +2,15 @@ use core::ffi::c_int;
 
 use arceos_posix_api as api;
 
-pub(crate) fn sys_pipe2(fds: *mut i32) -> c_int {
-    let fds_slice: &mut [c_int] = unsafe { core::slice::from_raw_parts_mut(fds, 2) };
-    api::sys_pipe(fds_slice)
+use crate::{
+    ptr::{PtrWrapper, UserPtr},
+    syscall_body,
+};
+
+pub(crate) fn sys_pipe2(fds: UserPtr<i32>) -> c_int {
+    syscall_body!(sys_pipe2, {
+        let fds = fds.get_as_array(2)?;
+        let fds_slice: &mut [c_int] = unsafe { core::slice::from_raw_parts_mut(fds, 2) };
+        Ok(api::sys_pipe(fds_slice))
+    })
 }

--- a/src/syscall_imp/fs/stat.rs
+++ b/src/syscall_imp/fs/stat.rs
@@ -3,8 +3,7 @@ use core::ffi::c_char;
 use axerrno::LinuxError;
 
 use crate::{
-    ptr::{PtrWrapper, UserConstPtr, UserPtr},
-    syscall_body, syscall_unwrap,
+    ptr::{PtrWrapper, UserConstPtr, UserPtr}, syscall_body, syscall_imp::read_path_str, syscall_unwrap
 };
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -185,7 +184,7 @@ pub(crate) fn sys_statx(
     //        file descriptor dirfd.
 
     syscall_body!(sys_statx, {
-        let path = arceos_posix_api::char_ptr_to_str(pathname.get_as_cstr()?)?;
+        let path = read_path_str(pathname)?;
 
         const AT_EMPTY_PATH: u32 = 0x1000;
         if path.is_empty() {

--- a/src/syscall_imp/fs/stat.rs
+++ b/src/syscall_imp/fs/stat.rs
@@ -1,8 +1,11 @@
-use core::ffi::c_void;
+use core::ffi::c_char;
 
 use axerrno::LinuxError;
 
-use crate::syscall_body;
+use crate::{
+    ptr::{PtrWrapper, UserConstPtr, UserPtr},
+    syscall_body, syscall_unwrap,
+};
 
 #[derive(Debug, Clone, Copy, Default)]
 #[repr(C)]
@@ -70,8 +73,8 @@ impl From<arceos_posix_api::ctypes::stat> for Kstat {
     }
 }
 
-pub(crate) fn sys_fstat(fd: i32, kstatbuf: *mut c_void) -> i32 {
-    let kstatbuf = kstatbuf as *mut Kstat;
+pub(crate) fn sys_fstat(fd: i32, kstatbuf: UserPtr<Kstat>) -> i32 {
+    let kstatbuf = syscall_unwrap!(kstatbuf.get());
     let mut statbuf = arceos_posix_api::ctypes::stat::default();
 
     if unsafe {
@@ -149,10 +152,10 @@ pub struct StatX {
 
 pub(crate) fn sys_statx(
     dirfd: i32,
-    pathname: *const u8,
+    pathname: UserConstPtr<c_char>,
     flags: u32,
     _mask: u32,
-    statxbuf: *mut c_void,
+    statxbuf: UserPtr<StatX>,
 ) -> i32 {
     // `statx()` uses pathname, dirfd, and flags to identify the target
     // file in one of the following ways:
@@ -182,7 +185,7 @@ pub(crate) fn sys_statx(
     //        file descriptor dirfd.
 
     syscall_body!(sys_statx, {
-        let path = arceos_posix_api::char_ptr_to_str(pathname as *const _)?;
+        let path = arceos_posix_api::char_ptr_to_str(pathname.get_as_cstr()?)?;
 
         const AT_EMPTY_PATH: u32 = 0x1000;
         if path.is_empty() {
@@ -195,7 +198,7 @@ pub(crate) fn sys_statx(
             if res < 0 {
                 return Err(LinuxError::try_from(-res).unwrap());
             }
-            let statx = unsafe { &mut *(statxbuf as *mut StatX) };
+            let statx = unsafe { &mut *statxbuf.get()? };
             statx.stx_blksize = status.st_blksize as u32;
             statx.stx_attributes = status.st_mode as u64;
             statx.stx_nlink = status.st_nlink;

--- a/src/syscall_imp/fs/stat.rs
+++ b/src/syscall_imp/fs/stat.rs
@@ -3,7 +3,10 @@ use core::ffi::c_char;
 use axerrno::LinuxError;
 
 use crate::{
-    ptr::{PtrWrapper, UserConstPtr, UserPtr}, syscall_body, syscall_imp::read_path_str, syscall_unwrap
+    ptr::{PtrWrapper, UserConstPtr, UserPtr},
+    syscall_body,
+    syscall_imp::read_path_str,
+    syscall_unwrap,
 };
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/src/syscall_imp/mod.rs
+++ b/src/syscall_imp/mod.rs
@@ -109,6 +109,8 @@ fn handle_syscall(tf: &TrapFrame, syscall_num: usize) -> isize {
             tf.arg2() as _,
             tf.arg3() as _,
         ) as _,
+        #[cfg(target_arch = "x86_64")]
+        Sysno::open => sys_open(tf.arg0().into(), tf.arg1() as _, tf.arg2() as _) as _,
         Sysno::getdents64 => sys_getdents64(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
         Sysno::linkat => sys_linkat(
             tf.arg0() as _,

--- a/src/syscall_imp/mod.rs
+++ b/src/syscall_imp/mod.rs
@@ -79,7 +79,7 @@ fn handle_syscall(tf: &TrapFrame, syscall_num: usize) -> isize {
             tf.arg4() as _,
             tf.arg5() as _,
         ) as _,
-        Sysno::ioctl => sys_ioctl(tf.arg0() as _, tf.arg1().into(), tf.arg2().into()) as _,
+        Sysno::ioctl => sys_ioctl(tf.arg0() as _, tf.arg1() as _, tf.arg2().into()) as _,
         Sysno::writev => sys_writev(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
         Sysno::sched_yield => sys_sched_yield() as isize,
         Sysno::nanosleep => sys_nanosleep(tf.arg0().into(), tf.arg1().into()) as _,

--- a/src/syscall_imp/mod.rs
+++ b/src/syscall_imp/mod.rs
@@ -16,6 +16,20 @@ use self::mm::*;
 use self::task::*;
 use self::utils::*;
 
+/// Macro to unwrap a LinuxResult<_> into isize, returning -errno on error
+#[macro_export]
+macro_rules! syscall_unwrap {
+    ($expr:expr) => {
+        match $expr {
+            Ok(v) => v,
+            Err(e) => {
+                info!("syscall => {:?}", e);
+                return -e.code() as _;
+            }
+        }
+    };
+}
+
 /// Macro to generate syscall body
 ///
 /// It will receive a function which return Result<_, LinuxError> and convert it to
@@ -43,25 +57,25 @@ fn handle_syscall(tf: &TrapFrame, syscall_num: usize) -> isize {
     info!("Syscall {:?}", Sysno::from(syscall_num as u32));
     time_stat_from_user_to_kernel();
     let ans = match Sysno::from(syscall_num as u32) {
-        Sysno::read => sys_read(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _),
-        Sysno::write => sys_write(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _),
+        Sysno::read => sys_read(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
+        Sysno::write => sys_write(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
         Sysno::mmap => sys_mmap(
-            tf.arg0() as _,
+            tf.arg0().into(),
             tf.arg1() as _,
             tf.arg2() as _,
             tf.arg3() as _,
             tf.arg4() as _,
             tf.arg5() as _,
         ) as _,
-        Sysno::ioctl => sys_ioctl(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _) as _,
-        Sysno::writev => sys_writev(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _),
+        Sysno::ioctl => sys_ioctl(tf.arg0() as _, tf.arg1().into(), tf.arg2().into()) as _,
+        Sysno::writev => sys_writev(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
         Sysno::sched_yield => sys_sched_yield() as isize,
-        Sysno::nanosleep => sys_nanosleep(tf.arg0() as _, tf.arg1() as _) as _,
+        Sysno::nanosleep => sys_nanosleep(tf.arg0().into(), tf.arg1().into()) as _,
         Sysno::getpid => sys_getpid() as isize,
         Sysno::getppid => sys_getppid() as isize,
         Sysno::exit => sys_exit(tf.arg0() as _),
-        Sysno::gettimeofday => sys_get_time_of_day(tf.arg0() as _) as _,
-        Sysno::getcwd => sys_getcwd(tf.arg0() as _, tf.arg1() as _) as _,
+        Sysno::gettimeofday => sys_get_time_of_day(tf.arg0().into()) as _,
+        Sysno::getcwd => sys_getcwd(tf.arg0().into(), tf.arg1() as _) as _,
         Sysno::dup => sys_dup(tf.arg0() as _) as _,
         Sysno::dup3 => sys_dup3(tf.arg0() as _, tf.arg1() as _) as _,
         Sysno::clone => sys_clone(
@@ -71,45 +85,43 @@ fn handle_syscall(tf: &TrapFrame, syscall_num: usize) -> isize {
             tf.arg3() as _,
             tf.arg4() as _,
         ) as _,
-        Sysno::wait4 => sys_wait4(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _) as _,
-        Sysno::pipe2 => sys_pipe2(tf.arg0() as _) as _,
+        Sysno::wait4 => sys_wait4(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _) as _,
+        Sysno::pipe2 => sys_pipe2(tf.arg0().into()) as _,
         Sysno::close => sys_close(tf.arg0() as _) as _,
-        Sysno::chdir => sys_chdir(tf.arg0() as _) as _,
-        Sysno::mkdirat => sys_mkdirat(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _) as _,
-        Sysno::execve => sys_execve(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _) as _,
+        Sysno::chdir => sys_chdir(tf.arg0().into()) as _,
+        Sysno::mkdirat => sys_mkdirat(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _) as _,
+        Sysno::execve => sys_execve(tf.arg0().into(), tf.arg1().into(), tf.arg2().into()) as _,
         Sysno::openat => sys_openat(
             tf.arg0() as _,
-            tf.arg1() as _,
+            tf.arg1().into(),
             tf.arg2() as _,
             tf.arg3() as _,
         ) as _,
-        #[cfg(target_arch = "x86_64")]
-        Sysno::open => sys_open(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _) as _,
-        Sysno::getdents64 => sys_getdents64(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _),
+        Sysno::getdents64 => sys_getdents64(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
         Sysno::linkat => sys_linkat(
             tf.arg0() as _,
-            tf.arg1() as _,
+            tf.arg1().into(),
             tf.arg2() as _,
-            tf.arg3() as _,
+            tf.arg3().into(),
             tf.arg4() as _,
         ) as _,
-        Sysno::unlinkat => sys_unlinkat(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _),
-        Sysno::uname => sys_uname(tf.arg0() as _) as _,
-        Sysno::fstat => sys_fstat(tf.arg0() as _, tf.arg1() as _) as _,
+        Sysno::unlinkat => sys_unlinkat(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
+        Sysno::uname => sys_uname(tf.arg0().into()) as _,
+        Sysno::fstat => sys_fstat(tf.arg0() as _, tf.arg1().into()) as _,
         Sysno::statx => sys_statx(
             tf.arg0() as _,
-            tf.arg1() as _,
+            tf.arg1().into(),
             tf.arg2() as _,
             tf.arg3() as _,
-            tf.arg4() as _,
+            tf.arg4().into(),
         ) as _,
-        Sysno::munmap => sys_munmap(tf.arg0() as _, tf.arg1() as _) as _,
-        Sysno::times => sys_times(tf.arg0() as _) as _,
+        Sysno::munmap => sys_munmap(tf.arg0().into(), tf.arg1() as _) as _,
+        Sysno::times => sys_times(tf.arg0().into()) as _,
         Sysno::brk => sys_brk(tf.arg0() as _) as _,
         #[cfg(target_arch = "x86_64")]
         Sysno::arch_prctl => sys_arch_prctl(tf.arg0() as _, tf.arg1() as _),
-        Sysno::set_tid_address => sys_set_tid_address(tf.arg0() as _),
-        Sysno::clock_gettime => sys_clock_gettime(tf.arg0() as _, tf.arg1() as _) as _,
+        Sysno::set_tid_address => sys_set_tid_address(tf.arg0().into()),
+        Sysno::clock_gettime => sys_clock_gettime(tf.arg0() as _, tf.arg1().into()) as _,
         Sysno::exit_group => sys_exit_group(tf.arg0() as _),
         _ => {
             warn!("Unimplemented syscall: {}", syscall_num);

--- a/src/syscall_imp/mod.rs
+++ b/src/syscall_imp/mod.rs
@@ -3,7 +3,12 @@ mod mm;
 mod task;
 mod utils;
 
-use crate::task::{time_stat_from_kernel_to_user, time_stat_from_user_to_kernel};
+use core::ffi::c_char;
+
+use crate::{
+    ptr::{PtrWrapper, UserConstPtr},
+    task::{time_stat_from_kernel_to_user, time_stat_from_user_to_kernel},
+};
 use axerrno::LinuxError;
 use axhal::{
     arch::TrapFrame,
@@ -50,6 +55,13 @@ macro_rules! syscall_body {
             }
         }
     }};
+}
+
+pub(crate) fn read_path_str(path: UserConstPtr<c_char>) -> Result<&'static str, LinuxError> {
+    path.get_as_cstr()?.to_str().map_err(|_| {
+        warn!("Invalid path");
+        LinuxError::EFAULT
+    })
 }
 
 #[register_trap_handler(SYSCALL)]

--- a/src/syscall_imp/task/schedule.rs
+++ b/src/syscall_imp/task/schedule.rs
@@ -1,12 +1,19 @@
 use arceos_posix_api as api;
 
+use crate::{
+    ptr::{PtrWrapper, UserConstPtr, UserPtr},
+    syscall_body,
+};
+
 pub(crate) fn sys_sched_yield() -> i32 {
     api::sys_sched_yield()
 }
 
 pub(crate) fn sys_nanosleep(
-    req: *const api::ctypes::timespec,
-    rem: *mut api::ctypes::timespec,
+    req: UserConstPtr<api::ctypes::timespec>,
+    rem: UserPtr<api::ctypes::timespec>,
 ) -> i32 {
-    unsafe { api::sys_nanosleep(req, rem) }
+    syscall_body!(sys_nanosleep, unsafe {
+        Ok(api::sys_nanosleep(req.get()?, rem.get()?))
+    })
 }

--- a/src/syscall_imp/task/thread.rs
+++ b/src/syscall_imp/task/thread.rs
@@ -6,6 +6,7 @@ use num_enum::TryFromPrimitive;
 
 use crate::{
     ctypes::{WaitFlags, WaitStatus},
+    ptr::{PtrWrapper, UserConstPtr, UserPtr},
     syscall_body,
     task::wait_pid,
 };
@@ -65,10 +66,11 @@ pub(crate) fn sys_exit_group(status: i32) -> ! {
 /// To set the clear_child_tid field in the task extended data.
 ///
 /// The set_tid_address() always succeeds
-pub(crate) fn sys_set_tid_address(tid_ptd: *const i32) -> isize {
+pub(crate) fn sys_set_tid_address(tid_ptd: UserConstPtr<i32>) -> isize {
     syscall_body!(sys_set_tid_address, {
         let curr = current();
-        curr.task_ext().set_clear_child_tid(tid_ptd as _);
+        curr.task_ext()
+            .set_clear_child_tid(tid_ptd.address().as_ptr() as _);
         Ok(curr.id().as_u64() as isize)
     })
 }
@@ -138,9 +140,10 @@ pub(crate) fn sys_clone(
     })
 }
 
-pub(crate) fn sys_wait4(pid: i32, exit_code_ptr: *mut i32, option: u32) -> isize {
+pub(crate) fn sys_wait4(pid: i32, exit_code_ptr: UserPtr<i32>, option: u32) -> isize {
     let option_flag = WaitFlags::from_bits(option).unwrap();
     syscall_body!(sys_wait4, {
+        let exit_code_ptr = exit_code_ptr.get()?;
         loop {
             let answer = wait_pid(pid, exit_code_ptr);
             match answer {
@@ -167,9 +170,13 @@ pub(crate) fn sys_wait4(pid: i32, exit_code_ptr: *mut i32, option: u32) -> isize
     })
 }
 
-pub fn sys_execve(path: *const c_char, argv: *const usize, envp: *const usize) -> isize {
+pub fn sys_execve(
+    path: UserConstPtr<c_char>,
+    argv: UserConstPtr<usize>,
+    envp: UserConstPtr<usize>,
+) -> isize {
     syscall_body!(sys_execve, {
-        let path_str = arceos_posix_api::char_ptr_to_str(path)?;
+        let path_str = arceos_posix_api::char_ptr_to_str(path.get_as_cstr()?)?;
 
         info!("execve: {:?}", path_str);
         if path_str.split('/').filter(|s| !s.is_empty()).count() > 1 {
@@ -177,6 +184,8 @@ pub fn sys_execve(path: *const c_char, argv: *const usize, envp: *const usize) -
             return Err::<isize, _>(LinuxError::EINVAL);
         }
 
+        let argv = argv.get()?;
+        let envp = envp.get()?;
         let argv_valid = unsafe { argv.is_null() || *argv == 0 };
         let envp_valid = unsafe { envp.is_null() || *envp == 0 };
 

--- a/src/syscall_imp/task/thread.rs
+++ b/src/syscall_imp/task/thread.rs
@@ -8,6 +8,7 @@ use crate::{
     ctypes::{WaitFlags, WaitStatus},
     ptr::{PtrWrapper, UserConstPtr, UserPtr},
     syscall_body,
+    syscall_imp::read_path_str,
     task::wait_pid,
 };
 
@@ -176,7 +177,7 @@ pub fn sys_execve(
     envp: UserConstPtr<usize>,
 ) -> isize {
     syscall_body!(sys_execve, {
-        let path_str = arceos_posix_api::char_ptr_to_str(path.get_as_cstr()?)?;
+        let path_str = read_path_str(path)?;
 
         info!("execve: {:?}", path_str);
         if path_str.split('/').filter(|s| !s.is_empty()).count() > 1 {

--- a/src/syscall_imp/utils/system_info.rs
+++ b/src/syscall_imp/utils/system_info.rs
@@ -1,3 +1,8 @@
+use crate::{
+    ptr::{PtrWrapper, UserPtr},
+    syscall_body,
+};
+
 #[repr(C)]
 pub struct UtsName {
     /// sysname
@@ -35,8 +40,9 @@ impl UtsName {
     }
 }
 
-pub fn sys_uname(name: *mut UtsName) -> i64 {
-    let utsname = unsafe { &mut *name };
-    *utsname = UtsName::default();
-    0
+pub fn sys_uname(name: UserPtr<UtsName>) -> i64 {
+    syscall_body!(sys_uname, {
+        unsafe { *name.get()? = UtsName::default() };
+        Ok(0)
+    })
 }

--- a/src/syscall_imp/utils/time.rs
+++ b/src/syscall_imp/utils/time.rs
@@ -3,21 +3,30 @@ use core::ffi::c_int;
 use arceos_posix_api::{self as api, ctypes::timeval};
 use axhal::time::{monotonic_time_nanos, nanos_to_ticks};
 
-use crate::{ctypes::Tms, syscall_body, task::time_stat_output};
+use crate::{
+    ctypes::Tms,
+    ptr::{PtrWrapper, UserPtr},
+    syscall_body,
+    task::time_stat_output,
+};
 
-pub(crate) fn sys_clock_gettime(clock_id: i32, tp: *mut api::ctypes::timespec) -> i32 {
-    unsafe { api::sys_clock_gettime(clock_id, tp) }
+pub(crate) fn sys_clock_gettime(clock_id: i32, tp: UserPtr<api::ctypes::timespec>) -> i32 {
+    syscall_body!(sys_clock_gettime, unsafe {
+        Ok(api::sys_clock_gettime(clock_id, tp.get()?))
+    })
 }
 
-pub(crate) fn sys_get_time_of_day(ts: *mut timeval) -> c_int {
-    unsafe { api::sys_get_time_of_day(ts) }
+pub(crate) fn sys_get_time_of_day(ts: UserPtr<timeval>) -> c_int {
+    syscall_body!(sys_get_time_of_day, unsafe {
+        Ok(api::sys_get_time_of_day(ts.get()?))
+    })
 }
 
-pub fn sys_times(tms: *mut Tms) -> isize {
+pub fn sys_times(tms: UserPtr<Tms>) -> isize {
     syscall_body!(sys_times, {
         let (_, utime_us, _, stime_us) = time_stat_output();
         unsafe {
-            *tms = Tms {
+            *tms.get()? = Tms {
                 tms_utime: utime_us,
                 tms_stime: stime_us,
                 tms_cutime: utime_us,


### PR DESCRIPTION
This PR introduced two new types for pointers: `UserPtr<T>` and `UserConstPtr<T>`; and trait `PtrWrapper<T>` to represent a pointer into user space memory.

Converting from these new types into raw pointers requires mandatory check of validity of that memory region, specified by either the layout of `T` itself or other memory region types like array (`[T; N]`) or C-String. This enhanaces security and conforms to Linux standards.

Existing syscalls are all refactored.