### PR TITLE
Fix `clone_task` on `x86_64` and `aarch64`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "axio"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8ca9c10ea4cd42bda87a2abde281fb481c76a0b05976fd03697385ea65d5122"
+checksum = "30aa258a37c25c5e9d3ff45ec80e728ff7c499586e3e40719daf7908f10fd5bd"
 dependencies = [
  "axerrno",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ dependencies = [
 [[package]]
 name = "lwext4_rust"
 version = "0.2.0"
-source = "git+https://github.com/Azure-stars/lwext4_rust.git#62519fadd8eece40cd6bbe9bb11943610cfcb908"
+source = "git+https://github.com/Azure-stars/lwext4_rust.git#ee5131ca3fbb03f39ea0878431aadb521d191122"
 dependencies = [
  "log",
 ]

--- a/src/task.rs
+++ b/src/task.rs
@@ -107,6 +107,7 @@ impl TaskExt {
             new_uctx.set_sp(stack);
         }
         // Skip current instruction
+        #[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))]
         new_uctx.set_ip(new_uctx.get_ip() + 4);
         new_uctx.set_retval(0);
         let return_id: u64 = new_task.id().as_u64();


### PR DESCRIPTION
On `x86_64` and `aarch64` the instruction pointer should not be bumped for the newly created task.