### PR TITLE
feat: exec args & envs

### DIFF
--- a/apps/oscomp/judge_basic.py
+++ b/apps/oscomp/judge_basic.py
@@ -451,6 +451,7 @@ def get_runner(name):
 target_testcases = [
     "test_brk",
     "test_chdir",
+    "test_execve",
 ]
 
 if __name__ == '__main__':

--- a/scripts/oscomp_test.sh
+++ b/scripts/oscomp_test.sh
@@ -35,6 +35,7 @@ fi
 basic_testlist=(
     "/$LIBC/basic/brk"
     "/$LIBC/basic/chdir"
+    "/$LIBC/basic/execve"
 )
 busybox_testlist=("/$LIBC/busybox sh /$LIBC/busybox_testcode.sh")
 iozone_testlist=("/$LIBC/busybox sh /$LIBC/iozone_testcode.sh")

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@
 #[macro_use]
 extern crate log;
 extern crate alloc;
-extern crate axstd;
 
 mod ctypes;
 
@@ -14,11 +13,34 @@ mod ptr;
 mod syscall_imp;
 mod task;
 
-use alloc::{string::ToString, sync::Arc, vec};
+use alloc::{
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
 use axhal::arch::UspaceContext;
-use axstd::println;
 use axsync::Mutex;
 use memory_addr::VirtAddr;
+
+fn run_user_app(args: &[String], envs: &[String]) -> Option<i32> {
+    let mut uspace = axmm::new_user_aspace(
+        VirtAddr::from_usize(axconfig::plat::USER_SPACE_BASE),
+        axconfig::plat::USER_SPACE_SIZE,
+    )
+    .expect("Failed to create user address space");
+
+    let path = arceos_posix_api::FilePath::new(&args[0]).expect("Invalid file path");
+    axfs::api::set_current_dir(path.parent().unwrap()).expect("Failed to set current dir");
+
+    let (entry_vaddr, ustack_top) = mm::load_user_app(&mut uspace, args, envs)
+        .unwrap_or_else(|e| panic!("Failed to load user app: {}", e));
+    let user_task = task::spawn_user_task(
+        Arc::new(Mutex::new(uspace)),
+        UspaceContext::new(entry_vaddr.into(), ustack_top, 2333),
+        axconfig::plat::USER_HEAP_BASE as _,
+    );
+    user_task.join()
+}
 
 #[unsafe(no_mangle)]
 fn main() {
@@ -26,24 +48,14 @@ fn main() {
         .unwrap_or_else(|| "Please specify the testcases list by making user_apps")
         .split(',')
         .filter(|&x| !x.is_empty());
-    println!("#### OS COMP TEST GROUP START basic-musl ####");
-    for testcase in testcases {
-        println!("Testing {}: ", testcase.split('/').next_back().unwrap());
 
-        let args = vec![testcase.to_string()];
-        let mut uspace = axmm::new_user_aspace(
-            VirtAddr::from_usize(axconfig::plat::USER_SPACE_BASE),
-            axconfig::plat::USER_SPACE_SIZE,
-        )
-        .expect("Failed to create user address space");
-        let (entry_vaddr, ustack_top) = mm::load_user_app(&mut (args.into()), &mut uspace).unwrap();
-        let user_task = task::spawn_user_task(
-            Arc::new(Mutex::new(uspace)),
-            UspaceContext::new(entry_vaddr.into(), ustack_top, 2333),
-            axconfig::plat::USER_HEAP_BASE as _,
-        );
-        let exit_code = user_task.join();
+    for testcase in testcases {
+        let args = testcase
+            .split_ascii_whitespace()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+
+        let exit_code = run_user_app(&args, &[]);
         info!("User task {} exited with code: {:?}", testcase, exit_code);
     }
-    println!("#### OS COMP TEST GROUP END basic-musl ####");
 }

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -235,11 +235,11 @@ static_assertions::const_assert_eq!(size_of::<c_char>(), size_of::<u8>());
 
 impl UserConstPtr<c_char> {
     /// Get the pointer as `&str`, validating the memory region.
-    pub fn get_as_str(self) -> LinuxResult<Option<&'static str>> {
+    pub fn get_as_str(self) -> LinuxResult<&'static str> {
         let slice = self.get_as_null_terminated()?;
         // SAFETY: c_char is u8
         let slice = unsafe { mem::transmute::<&[c_char], &[u8]>(slice) };
 
-        Ok(str::from_utf8(slice).ok())
+        str::from_utf8(slice).map_err(|_| LinuxError::EILSEQ)
     }
 }

--- a/src/syscall_imp/fs/ctl.rs
+++ b/src/syscall_imp/fs/ctl.rs
@@ -7,9 +7,7 @@ use axtask::{TaskExtRef, current};
 
 use crate::{
     ptr::{PtrWrapper, UserConstPtr, UserPtr},
-    syscall_body,
-    syscall_imp::read_path_str,
-    syscall_unwrap,
+    syscall_body, syscall_unwrap,
 };
 
 /// The ioctl() system call manipulates the underlying device parameters
@@ -28,7 +26,7 @@ pub(crate) fn sys_ioctl(_fd: i32, _op: usize, _argp: UserPtr<c_void>) -> i32 {
 }
 
 pub(crate) fn sys_chdir(path: UserConstPtr<c_char>) -> c_int {
-    let path = syscall_unwrap!(read_path_str(path));
+    let path = syscall_unwrap!(path.get_as_str());
     axfs::api::set_current_dir(path)
         .map(|_| 0)
         .unwrap_or_else(|err| {
@@ -38,7 +36,7 @@ pub(crate) fn sys_chdir(path: UserConstPtr<c_char>) -> c_int {
 }
 
 pub(crate) fn sys_mkdirat(dirfd: i32, path: UserConstPtr<c_char>, mode: u32) -> c_int {
-    let path = syscall_unwrap!(read_path_str(path));
+    let path = syscall_unwrap!(path.get_as_str());
 
     if !path.starts_with("/") && dirfd != AT_FDCWD as i32 {
         warn!("unsupported.");

--- a/src/syscall_imp/fs/stat.rs
+++ b/src/syscall_imp/fs/stat.rs
@@ -4,9 +4,7 @@ use axerrno::LinuxError;
 
 use crate::{
     ptr::{PtrWrapper, UserConstPtr, UserPtr},
-    syscall_body,
-    syscall_imp::read_path_str,
-    syscall_unwrap,
+    syscall_body, syscall_unwrap,
 };
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -219,7 +217,7 @@ pub fn sys_statx(
     //        file descriptor dirfd.
 
     syscall_body!(sys_statx, {
-        let path = read_path_str(pathname)?;
+        let path = pathname.get_as_str()?;
 
         const AT_EMPTY_PATH: u32 = 0x1000;
         if path.is_empty() {

--- a/src/syscall_imp/mod.rs
+++ b/src/syscall_imp/mod.rs
@@ -5,12 +5,7 @@ mod sys;
 mod task;
 mod utils;
 
-use core::ffi::c_char;
-
-use crate::{
-    ptr::UserConstPtr,
-    task::{time_stat_from_kernel_to_user, time_stat_from_user_to_kernel},
-};
+use crate::task::{time_stat_from_kernel_to_user, time_stat_from_user_to_kernel};
 use axerrno::LinuxError;
 use axhal::{
     arch::TrapFrame,
@@ -59,13 +54,6 @@ macro_rules! syscall_body {
             }
         }
     }};
-}
-
-pub(crate) fn read_path_str(path: UserConstPtr<c_char>) -> Result<&'static str, LinuxError> {
-    path.get_as_str()?.ok_or_else(|| {
-        warn!("Invalid path");
-        LinuxError::EFAULT
-    })
 }
 
 #[register_trap_handler(SYSCALL)]

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,4 +1,8 @@
-use alloc::{string::ToString, sync::Arc, vec, vec::Vec};
+use alloc::{
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
 use arceos_posix_api::FD_TABLE;
 use axerrno::{AxError, AxResult};
 use axfs::{CURRENT_DIR, CURRENT_DIR_PATH};
@@ -115,7 +119,7 @@ impl TaskExt {
             return_id as usize,
             new_uctx,
             Arc::new(Mutex::new(new_aspace)),
-            0,
+            axconfig::plat::USER_HEAP_BASE as _,
         );
         new_task_ext.ns_init_new();
         new_task.init_task_ext(new_task_ext);
@@ -327,7 +331,7 @@ pub fn wait_pid(pid: i32, exit_code_ptr: *mut i32) -> Result<u64, WaitStatus> {
     Err(answer_status)
 }
 
-pub fn exec(name: &str) -> AxResult<()> {
+pub fn exec(name: &str, args: &[String], envs: &[String]) -> AxResult<()> {
     let current_task = current();
 
     let program_name = name.to_string();
@@ -341,14 +345,13 @@ pub fn exec(name: &str) -> AxResult<()> {
     aspace.unmap_user_areas()?;
     axhal::arch::flush_tlb(None);
 
-    let args = vec![program_name];
-
-    let (entry_point, user_stack_base) = crate::mm::load_user_app(&mut (args.into()), &mut aspace)
+    let (entry_point, user_stack_base) = crate::mm::load_user_app(&mut aspace, args, envs)
         .map_err(|_| {
-            error!("Failed to load app {}", name);
+            error!("Failed to load app {}", program_name);
             AxError::NotFound
         })?;
-    current_task.set_name(name);
+    current_task.set_name(&program_name);
+    drop(aspace);
 
     let task_ext = unsafe { &mut *(current_task.task_ext_ptr() as *mut TaskExt) };
     task_ext.uctx = UspaceContext::new(entry_point.as_usize(), user_stack_base, 0);


### PR DESCRIPTION
This PR mainly adds support for `args` and `envs` for `exec`. Additionally, several issues closely related to `exec` have been fixed:
1. Testcases should run in the same directory as the executable
2. `libc.so` path should be absolute
3. `clone_task` should set user heap base
4. `current_task.set_name` should not reference data in the old user space
5. `MutexGuard<AddrSpace>` should be dropped before entering user space