### PR TITLE
Unify syscall style & fix errorcode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a82271f7bc033d84bbca59a3ce3e4159938cb08a9c3aebbe54d215131518a13"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dd856d451cc0da70e2ef2ce95a18e39a93b7558bedf10201ad28503f918568"
+
+[[package]]
 name = "managed"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +1435,7 @@ dependencies = [
  "kernel-elf-parser",
  "linkme",
  "log",
+ "macro_rules_attribute",
  "memory_addr",
  "num_enum",
  "numeric-enum-macro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ num_enum = { version = "0.7", default-features = false }
 syscalls = { version = "0.6", default-features = false }
 numeric-enum-macro = "0.2.0"
 static_assertions = "1.1.0"
+macro_rules_attribute = "0.2.0"
 
 axconfig = { git = "https://github.com/oscomp/arceos.git" }
 axfs = { git = "https://github.com/oscomp/arceos.git" }

--- a/src/syscall_imp/fs/ctl.rs
+++ b/src/syscall_imp/fs/ctl.rs
@@ -1,12 +1,13 @@
-use core::ffi::{c_char, c_int, c_void};
+use core::ffi::{c_char, c_void};
 
 use alloc::string::ToString;
 use arceos_posix_api::AT_FDCWD;
-use axerrno::{AxError, LinuxError};
+use axerrno::{AxError, LinuxError, LinuxResult};
+use macro_rules_attribute::apply;
 
 use crate::{
     ptr::{PtrWrapper, UserConstPtr, UserPtr},
-    syscall_body, syscall_unwrap,
+    syscall_imp::instrument,
 };
 
 /// The ioctl() system call manipulates the underlying device parameters
@@ -17,41 +18,36 @@ use crate::{
 /// * `op` - The request code. It is of type unsigned long in glibc and BSD,
 ///   and of type int in musl and other UNIX systems.
 /// * `argp` - The argument to the request. It is a pointer to a memory location
-pub(crate) fn sys_ioctl(_fd: i32, _op: usize, _argp: UserPtr<c_void>) -> i32 {
-    syscall_body!(sys_ioctl, {
-        warn!("Unimplemented syscall: SYS_IOCTL");
-        Ok(0)
+#[apply(instrument)]
+pub fn sys_ioctl(_fd: i32, _op: usize, _argp: UserPtr<c_void>) -> LinuxResult<isize> {
+    warn!("Unimplemented syscall: SYS_IOCTL");
+    Ok(0)
+}
+
+pub fn sys_chdir(path: UserConstPtr<c_char>) -> LinuxResult<isize> {
+    let path = path.get_as_str()?;
+    axfs::api::set_current_dir(path).map(|_| 0).map_err(|err| {
+        warn!("Failed to change directory: {err:?}");
+        err.into()
     })
 }
 
-pub(crate) fn sys_chdir(path: UserConstPtr<c_char>) -> c_int {
-    let path = syscall_unwrap!(path.get_as_str());
-    axfs::api::set_current_dir(path)
-        .map(|_| 0)
-        .unwrap_or_else(|err| {
-            warn!("Failed to change directory: {err:?}");
-            -1
-        })
-}
-
-pub(crate) fn sys_mkdirat(dirfd: i32, path: UserConstPtr<c_char>, mode: u32) -> c_int {
-    let path = syscall_unwrap!(path.get_as_str());
+pub(crate) fn sys_mkdirat(dirfd: i32, path: UserConstPtr<c_char>, mode: u32) -> LinuxResult<isize> {
+    let path = path.get_as_str()?;
 
     if !path.starts_with("/") && dirfd != AT_FDCWD as i32 {
         warn!("unsupported.");
-        return -1;
+        return Err(LinuxError::EINVAL);
     }
 
     if mode != 0 {
         info!("directory mode not supported.");
     }
 
-    axfs::api::create_dir(path)
-        .map(|_| 0)
-        .unwrap_or_else(|err| {
-            warn!("Failed to create directory {path}: {err:?}");
-            -1
-        })
+    axfs::api::create_dir(path).map(|_| 0).map_err(|err| {
+        warn!("Failed to create directory {path}: {err:?}");
+        err.into()
+    })
 }
 
 #[repr(C)]
@@ -146,19 +142,19 @@ impl<'a> DirBuffer<'a> {
     }
 }
 
-pub(crate) fn sys_getdents64(fd: i32, buf: UserPtr<c_void>, len: usize) -> isize {
-    let buf = syscall_unwrap!(buf.get_as_bytes(len));
+pub fn sys_getdents64(fd: i32, buf: UserPtr<c_void>, len: usize) -> LinuxResult<isize> {
+    let buf = buf.get_as_bytes(len)?;
 
     if len < DirEnt::FIXED_SIZE {
         warn!("Buffer size too small: {len}");
-        return -LinuxError::EINVAL.code() as _;
+        return Err(LinuxError::EINVAL);
     }
 
     let path = match arceos_posix_api::Directory::from_fd(fd).map(|dir| dir.path().to_string()) {
         Ok(path) => path,
         Err(err) => {
             warn!("Invalid directory descriptor: {:?}", err);
-            return -LinuxError::EBADF.code() as _;
+            return Err(LinuxError::EBADF);
         }
     };
 
@@ -182,7 +178,6 @@ pub(crate) fn sys_getdents64(fd: i32, buf: UserPtr<c_void>, len: usize) -> isize
     };
 
     axfs::api::read_dir(&path)
-        .map_err(|_| LinuxError::EINVAL as isize)
         .map(|entries| {
             let mut total_size = initial_offset as usize;
             let mut current_offset = initial_offset;
@@ -216,7 +211,7 @@ pub(crate) fn sys_getdents64(fd: i32, buf: UserPtr<c_void>, len: usize) -> isize
 
             total_size as isize
         })
-        .unwrap_or(LinuxError::ENOENT as isize)
+        .map_err(|err| err.into())
 }
 
 /// create a link from new_path to old_path
@@ -224,15 +219,15 @@ pub(crate) fn sys_getdents64(fd: i32, buf: UserPtr<c_void>, len: usize) -> isize
 /// new_path: new file path
 /// flags: link flags
 /// return value: return 0 when success, else return -1.
-pub(crate) fn sys_linkat(
+pub fn sys_linkat(
     old_dirfd: i32,
     old_path: UserConstPtr<c_char>,
     new_dirfd: i32,
     new_path: UserConstPtr<c_char>,
     flags: i32,
-) -> i32 {
-    let old_path = syscall_unwrap!(old_path.get_as_null_terminated());
-    let new_path = syscall_unwrap!(new_path.get_as_null_terminated());
+) -> LinuxResult<isize> {
+    let old_path = old_path.get_as_null_terminated()?;
+    let new_path = new_path.get_as_null_terminated()?;
 
     if flags != 0 {
         warn!("Unsupported flags: {flags}");
@@ -258,7 +253,7 @@ pub(crate) fn sys_linkat(
                 .map_err(Into::into)
         })
         .map(|_| 0)
-        .unwrap_or(-1)
+        .map_err(|err| err.into())
 }
 
 /// remove link of specific file (can be used to delete file)
@@ -266,8 +261,8 @@ pub(crate) fn sys_linkat(
 /// path: the name of link to be removed
 /// flags: can be 0 or AT_REMOVEDIR
 /// return 0 when success, else return -1
-pub fn sys_unlinkat(dir_fd: isize, path: UserConstPtr<c_char>, flags: usize) -> isize {
-    let path = syscall_unwrap!(path.get_as_null_terminated());
+pub fn sys_unlinkat(dir_fd: isize, path: UserConstPtr<c_char>, flags: usize) -> LinuxResult<isize> {
+    let path = path.get_as_null_terminated()?;
 
     const AT_REMOVEDIR: usize = 0x200;
 
@@ -295,15 +290,9 @@ pub fn sys_unlinkat(dir_fd: isize, path: UserConstPtr<c_char>, flags: usize) -> 
                 })
             }
         })
-        .unwrap_or(-1)
+        .map_err(|err| err.into())
 }
 
-pub(crate) fn sys_getcwd(buf: UserPtr<c_char>, size: usize) -> *mut c_char {
-    syscall_body!(
-        sys_getcwd,
-        Ok(arceos_posix_api::sys_getcwd(
-            buf.get_as_null_terminated()?.as_ptr() as _,
-            size
-        ))
-    )
+pub fn sys_getcwd(buf: UserPtr<c_char>, size: usize) -> LinuxResult<isize> {
+    Ok(arceos_posix_api::sys_getcwd(buf.get_as_null_terminated()?.as_ptr() as _, size) as _)
 }

--- a/src/syscall_imp/fs/ctl.rs
+++ b/src/syscall_imp/fs/ctl.rs
@@ -7,7 +7,7 @@ use macro_rules_attribute::apply;
 
 use crate::{
     ptr::{PtrWrapper, UserConstPtr, UserPtr},
-    syscall_imp::instrument,
+    syscall_imp::syscall_instrument,
 };
 
 /// The ioctl() system call manipulates the underlying device parameters
@@ -18,7 +18,7 @@ use crate::{
 /// * `op` - The request code. It is of type unsigned long in glibc and BSD,
 ///   and of type int in musl and other UNIX systems.
 /// * `argp` - The argument to the request. It is a pointer to a memory location
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_ioctl(_fd: i32, _op: usize, _argp: UserPtr<c_void>) -> LinuxResult<isize> {
     warn!("Unimplemented syscall: SYS_IOCTL");
     Ok(0)

--- a/src/syscall_imp/fs/fd_ops.rs
+++ b/src/syscall_imp/fs/fd_ops.rs
@@ -1,19 +1,20 @@
 use core::ffi::c_int;
 
 use arceos_posix_api as api;
+use axerrno::LinuxResult;
 
-pub fn sys_dup(old_fd: c_int) -> c_int {
-    api::sys_dup(old_fd)
+pub fn sys_dup(old_fd: c_int) -> LinuxResult<isize> {
+    Ok(api::sys_dup(old_fd) as _)
 }
 
-pub fn sys_dup3(old_fd: c_int, new_fd: c_int) -> c_int {
-    api::sys_dup2(old_fd, new_fd)
+pub fn sys_dup3(old_fd: c_int, new_fd: c_int) -> LinuxResult<isize> {
+    Ok(api::sys_dup2(old_fd, new_fd) as _)
 }
 
-pub fn sys_close(fd: c_int) -> c_int {
-    api::sys_close(fd)
+pub fn sys_close(fd: c_int) -> LinuxResult<isize> {
+    Ok(api::sys_close(fd) as _)
 }
 
-pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> c_int {
-    api::sys_fcntl(fd, cmd, arg)
+pub fn sys_fcntl(fd: c_int, cmd: c_int, arg: usize) -> LinuxResult<isize> {
+    Ok(api::sys_fcntl(fd, cmd, arg) as _)
 }

--- a/src/syscall_imp/fs/io.rs
+++ b/src/syscall_imp/fs/io.rs
@@ -1,25 +1,27 @@
 use core::ffi::{c_char, c_void};
 
 use arceos_posix_api::{self as api, ctypes::mode_t};
+use axerrno::LinuxResult;
 
-use crate::{
-    ptr::{PtrWrapper, UserConstPtr, UserPtr},
-    syscall_unwrap,
-};
+use crate::ptr::{PtrWrapper, UserConstPtr, UserPtr};
 
-pub(crate) fn sys_read(fd: i32, buf: UserPtr<c_void>, count: usize) -> isize {
-    let buf = syscall_unwrap!(buf.get_as_bytes(count));
-    api::sys_read(fd, buf, count)
+pub(crate) fn sys_read(fd: i32, buf: UserPtr<c_void>, count: usize) -> LinuxResult<isize> {
+    let buf = buf.get_as_bytes(count)?;
+    Ok(api::sys_read(fd, buf, count))
 }
 
-pub(crate) fn sys_write(fd: i32, buf: UserConstPtr<c_void>, count: usize) -> isize {
-    let buf = syscall_unwrap!(buf.get_as_bytes(count));
-    api::sys_write(fd, buf, count)
+pub(crate) fn sys_write(fd: i32, buf: UserConstPtr<c_void>, count: usize) -> LinuxResult<isize> {
+    let buf = buf.get_as_bytes(count)?;
+    Ok(api::sys_write(fd, buf, count))
 }
 
-pub(crate) fn sys_writev(fd: i32, iov: UserConstPtr<api::ctypes::iovec>, iocnt: i32) -> isize {
-    let iov = syscall_unwrap!(iov.get_as_bytes(iocnt as _));
-    unsafe { api::sys_writev(fd, iov, iocnt) }
+pub(crate) fn sys_writev(
+    fd: i32,
+    iov: UserConstPtr<api::ctypes::iovec>,
+    iocnt: i32,
+) -> LinuxResult<isize> {
+    let iov = iov.get_as_bytes(iocnt as _)?;
+    unsafe { Ok(api::sys_writev(fd, iov, iocnt)) }
 }
 
 pub(crate) fn sys_openat(
@@ -27,13 +29,17 @@ pub(crate) fn sys_openat(
     path: UserConstPtr<c_char>,
     flags: i32,
     modes: mode_t,
-) -> isize {
-    let path = syscall_unwrap!(path.get_as_null_terminated());
-    api::sys_openat(dirfd, path.as_ptr(), flags, modes) as _
+) -> LinuxResult<isize> {
+    let path = path.get_as_null_terminated()?;
+    Ok(api::sys_openat(dirfd, path.as_ptr(), flags, modes) as _)
 }
 
 #[cfg(target_arch = "x86_64")]
-pub(crate) fn sys_open(path: UserConstPtr<c_char>, flags: i32, modes: mode_t) -> isize {
+pub(crate) fn sys_open(
+    path: UserConstPtr<c_char>,
+    flags: i32,
+    modes: mode_t,
+) -> LinuxResult<isize> {
     use arceos_posix_api::AT_FDCWD;
     sys_openat(AT_FDCWD as _, path, flags, modes)
 }

--- a/src/syscall_imp/fs/pipe.rs
+++ b/src/syscall_imp/fs/pipe.rs
@@ -1,16 +1,12 @@
 use core::ffi::c_int;
 
 use arceos_posix_api as api;
+use axerrno::LinuxResult;
 
-use crate::{
-    ptr::{PtrWrapper, UserPtr},
-    syscall_body,
-};
+use crate::ptr::{PtrWrapper, UserPtr};
 
-pub(crate) fn sys_pipe2(fds: UserPtr<i32>) -> c_int {
-    syscall_body!(sys_pipe2, {
-        let fds = fds.get_as_array(2)?;
-        let fds_slice: &mut [c_int] = unsafe { core::slice::from_raw_parts_mut(fds, 2) };
-        Ok(api::sys_pipe(fds_slice))
-    })
+pub fn sys_pipe2(fds: UserPtr<i32>) -> LinuxResult<isize> {
+    let fds = fds.get_as_array(2)?;
+    let fds_slice: &mut [c_int] = unsafe { core::slice::from_raw_parts_mut(fds, 2) };
+    Ok(api::sys_pipe(fds_slice) as _)
 }

--- a/src/syscall_imp/fs/stat.rs
+++ b/src/syscall_imp/fs/stat.rs
@@ -5,7 +5,7 @@ use macro_rules_attribute::apply;
 
 use crate::{
     ptr::{PtrWrapper, UserConstPtr, UserPtr},
-    syscall_imp::instrument,
+    syscall_imp::syscall_instrument,
 };
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -92,7 +92,7 @@ pub fn sys_fstat(fd: i32, kstatbuf: UserPtr<Kstat>) -> LinuxResult<isize> {
     Ok(0)
 }
 
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_fstatat(
     dir_fd: isize,
     path: UserConstPtr<c_char>,
@@ -182,7 +182,7 @@ pub struct StatX {
     pub stx_dio_offset_align: u32,
 }
 
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_statx(
     dirfd: i32,
     pathname: UserConstPtr<c_char>,

--- a/src/syscall_imp/fs/stat.rs
+++ b/src/syscall_imp/fs/stat.rs
@@ -1,10 +1,11 @@
 use core::ffi::c_char;
 
-use axerrno::LinuxError;
+use axerrno::{LinuxError, LinuxResult};
+use macro_rules_attribute::apply;
 
 use crate::{
     ptr::{PtrWrapper, UserConstPtr, UserPtr},
-    syscall_body, syscall_unwrap,
+    syscall_imp::instrument,
 };
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -73,54 +74,53 @@ impl From<arceos_posix_api::ctypes::stat> for Kstat {
     }
 }
 
-pub fn sys_fstat(fd: i32, kstatbuf: UserPtr<Kstat>) -> i32 {
-    let kstatbuf = syscall_unwrap!(kstatbuf.get());
+pub fn sys_fstat(fd: i32, kstatbuf: UserPtr<Kstat>) -> LinuxResult<isize> {
+    let kstatbuf = kstatbuf.get()?;
     let mut statbuf = arceos_posix_api::ctypes::stat::default();
 
     let result = unsafe {
         arceos_posix_api::sys_fstat(fd, &mut statbuf as *mut arceos_posix_api::ctypes::stat)
     };
     if result < 0 {
-        return result;
+        return Ok(result as _);
     }
 
     unsafe {
         let kstat = Kstat::from(statbuf);
         kstatbuf.write(kstat);
     }
-    0
+    Ok(0)
 }
 
+#[apply(instrument)]
 pub fn sys_fstatat(
     dir_fd: isize,
     path: UserConstPtr<c_char>,
     kstatbuf: UserPtr<Kstat>,
     _flags: i32,
-) -> i32 {
-    syscall_body!(sys_fstatat, {
-        let path = path.get_as_null_terminated()?;
-        let path = arceos_posix_api::handle_file_path(dir_fd, Some(path.as_ptr() as _), false)?;
+) -> LinuxResult<isize> {
+    let path = path.get_as_null_terminated()?;
+    let path = arceos_posix_api::handle_file_path(dir_fd, Some(path.as_ptr() as _), false)?;
 
-        let kstatbuf = kstatbuf.get()?;
+    let kstatbuf = kstatbuf.get()?;
 
-        let mut statbuf = arceos_posix_api::ctypes::stat::default();
-        let result = unsafe {
-            arceos_posix_api::sys_stat(
-                path.as_ptr() as _,
-                &mut statbuf as *mut arceos_posix_api::ctypes::stat,
-            )
-        };
-        if result < 0 {
-            return Ok(result);
-        }
+    let mut statbuf = arceos_posix_api::ctypes::stat::default();
+    let result = unsafe {
+        arceos_posix_api::sys_stat(
+            path.as_ptr() as _,
+            &mut statbuf as *mut arceos_posix_api::ctypes::stat,
+        )
+    };
+    if result < 0 {
+        return Ok(result as _);
+    }
 
-        unsafe {
-            let kstat = Kstat::from(statbuf);
-            kstatbuf.write(kstat);
-        }
+    unsafe {
+        let kstat = Kstat::from(statbuf);
+        kstatbuf.write(kstat);
+    }
 
-        Ok(0)
-    })
+    Ok(0)
 }
 
 #[repr(C)]
@@ -182,13 +182,14 @@ pub struct StatX {
     pub stx_dio_offset_align: u32,
 }
 
+#[apply(instrument)]
 pub fn sys_statx(
     dirfd: i32,
     pathname: UserConstPtr<c_char>,
     flags: u32,
     _mask: u32,
     statxbuf: UserPtr<StatX>,
-) -> i32 {
+) -> LinuxResult<isize> {
     // `statx()` uses pathname, dirfd, and flags to identify the target
     // file in one of the following ways:
 
@@ -216,40 +217,38 @@ pub fn sys_statx(
     //        below), then the target file is the one referred to by the
     //        file descriptor dirfd.
 
-    syscall_body!(sys_statx, {
-        let path = pathname.get_as_str()?;
+    let path = pathname.get_as_str()?;
 
-        const AT_EMPTY_PATH: u32 = 0x1000;
-        if path.is_empty() {
-            if flags & AT_EMPTY_PATH == 0 {
-                return Err(LinuxError::EINVAL);
-            }
-            // Alloc a new space for stat struct
-            let mut status = arceos_posix_api::ctypes::stat::default();
-            let res = unsafe { arceos_posix_api::sys_fstat(dirfd, &mut status as *mut _) };
-            if res < 0 {
-                return Err(LinuxError::try_from(-res).unwrap());
-            }
-            let statx = unsafe { &mut *statxbuf.get()? };
-            statx.stx_blksize = status.st_blksize as u32;
-            statx.stx_attributes = status.st_mode as u64;
-            statx.stx_nlink = status.st_nlink;
-            statx.stx_uid = status.st_uid;
-            statx.stx_gid = status.st_gid;
-            statx.stx_mode = status.st_mode as u16;
-            statx.stx_ino = status.st_ino;
-            statx.stx_size = status.st_size as u64;
-            statx.stx_blocks = status.st_blocks as u64;
-            statx.stx_attributes_mask = 0x7FF;
-            statx.stx_atime.tv_sec = status.st_atime.tv_sec;
-            statx.stx_atime.tv_nsec = status.st_atime.tv_nsec as u32;
-            statx.stx_ctime.tv_sec = status.st_ctime.tv_sec;
-            statx.stx_ctime.tv_nsec = status.st_ctime.tv_nsec as u32;
-            statx.stx_mtime.tv_sec = status.st_mtime.tv_sec;
-            statx.stx_mtime.tv_nsec = status.st_mtime.tv_nsec as u32;
-            Ok(0)
-        } else {
-            Err(LinuxError::ENOSYS)
+    const AT_EMPTY_PATH: u32 = 0x1000;
+    if path.is_empty() {
+        if flags & AT_EMPTY_PATH == 0 {
+            return Err(LinuxError::EINVAL);
         }
-    })
+        // Alloc a new space for stat struct
+        let mut status = arceos_posix_api::ctypes::stat::default();
+        let res = unsafe { arceos_posix_api::sys_fstat(dirfd, &mut status as *mut _) };
+        if res < 0 {
+            return Err(LinuxError::try_from(-res).unwrap());
+        }
+        let statx = unsafe { &mut *statxbuf.get()? };
+        statx.stx_blksize = status.st_blksize as u32;
+        statx.stx_attributes = status.st_mode as u64;
+        statx.stx_nlink = status.st_nlink;
+        statx.stx_uid = status.st_uid;
+        statx.stx_gid = status.st_gid;
+        statx.stx_mode = status.st_mode as u16;
+        statx.stx_ino = status.st_ino;
+        statx.stx_size = status.st_size as u64;
+        statx.stx_blocks = status.st_blocks as u64;
+        statx.stx_attributes_mask = 0x7FF;
+        statx.stx_atime.tv_sec = status.st_atime.tv_sec;
+        statx.stx_atime.tv_nsec = status.st_atime.tv_nsec as u32;
+        statx.stx_ctime.tv_sec = status.st_ctime.tv_sec;
+        statx.stx_ctime.tv_nsec = status.st_ctime.tv_nsec as u32;
+        statx.stx_mtime.tv_sec = status.st_mtime.tv_sec;
+        statx.stx_mtime.tv_nsec = status.st_mtime.tv_nsec as u32;
+        Ok(0)
+    } else {
+        Err(LinuxError::ENOSYS)
+    }
 }

--- a/src/syscall_imp/mm/brk.rs
+++ b/src/syscall_imp/mm/brk.rs
@@ -1,17 +1,17 @@
+use axerrno::LinuxResult;
 use axtask::{TaskExtRef, current};
+use macro_rules_attribute::apply;
 
-use crate::syscall_body;
+use crate::syscall_imp::instrument;
 
-pub fn sys_brk(addr: usize) -> isize {
-    syscall_body!(sys_brk, {
-        let current_task = current();
-        let mut return_val: isize = current_task.task_ext().get_heap_top() as isize;
-        let heap_bottom = current_task.task_ext().get_heap_bottom() as usize;
-        if addr != 0 && addr >= heap_bottom && addr <= heap_bottom + axconfig::plat::USER_HEAP_SIZE
-        {
-            current_task.task_ext().set_heap_top(addr as u64);
-            return_val = addr as isize;
-        }
-        Ok(return_val)
-    })
+#[apply(instrument)]
+pub fn sys_brk(addr: usize) -> LinuxResult<isize> {
+    let current_task = current();
+    let mut return_val: isize = current_task.task_ext().get_heap_top() as isize;
+    let heap_bottom = current_task.task_ext().get_heap_bottom() as usize;
+    if addr != 0 && addr >= heap_bottom && addr <= heap_bottom + axconfig::plat::USER_HEAP_SIZE {
+        current_task.task_ext().set_heap_top(addr as u64);
+        return_val = addr as isize;
+    }
+    Ok(return_val)
 }

--- a/src/syscall_imp/mm/brk.rs
+++ b/src/syscall_imp/mm/brk.rs
@@ -2,9 +2,9 @@ use axerrno::LinuxResult;
 use axtask::{TaskExtRef, current};
 use macro_rules_attribute::apply;
 
-use crate::syscall_imp::instrument;
+use crate::syscall_imp::syscall_instrument;
 
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_brk(addr: usize) -> LinuxResult<isize> {
     let current_task = current();
     let mut return_val: isize = current_task.task_ext().get_heap_top() as isize;

--- a/src/syscall_imp/mm/mmap.rs
+++ b/src/syscall_imp/mm/mmap.rs
@@ -7,7 +7,7 @@ use memory_addr::{VirtAddr, VirtAddrRange};
 
 use crate::{
     ptr::{PtrWrapper, UserPtr},
-    syscall_imp::instrument,
+    syscall_imp::syscall_instrument,
 };
 
 bitflags::bitflags! {
@@ -66,7 +66,7 @@ bitflags::bitflags! {
     }
 }
 
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_mmap(
     addr: UserPtr<usize>,
     length: usize,
@@ -157,7 +157,7 @@ pub fn sys_mmap(
     Ok(start_addr.as_usize() as _)
 }
 
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_munmap(addr: UserPtr<usize>, length: usize) -> LinuxResult<isize> {
     // Safety: addr is used for mapping, and we won't directly access it.
     let addr = unsafe { addr.into_inner() };
@@ -172,7 +172,7 @@ pub fn sys_munmap(addr: UserPtr<usize>, length: usize) -> LinuxResult<isize> {
     Ok(0)
 }
 
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_mprotect(addr: UserPtr<usize>, length: usize, prot: i32) -> LinuxResult<isize> {
     // Safety: addr is used for mapping, and we won't directly access it.
     let addr = unsafe { addr.into_inner() };

--- a/src/syscall_imp/mm/mmap.rs
+++ b/src/syscall_imp/mm/mmap.rs
@@ -1,12 +1,13 @@
 use alloc::vec;
-use axerrno::LinuxError;
+use axerrno::{LinuxError, LinuxResult};
 use axhal::paging::MappingFlags;
 use axtask::{TaskExtRef, current};
+use macro_rules_attribute::apply;
 use memory_addr::{VirtAddr, VirtAddrRange};
 
 use crate::{
     ptr::{PtrWrapper, UserPtr},
-    syscall_body,
+    syscall_imp::instrument,
 };
 
 bitflags::bitflags! {
@@ -65,6 +66,7 @@ bitflags::bitflags! {
     }
 }
 
+#[apply(instrument)]
 pub fn sys_mmap(
     addr: UserPtr<usize>,
     length: usize,
@@ -72,127 +74,123 @@ pub fn sys_mmap(
     flags: i32,
     fd: i32,
     offset: isize,
-) -> usize {
-    syscall_body!(sys_mmap, {
-        // Safety: addr is used for mapping, and we won't directly access it.
-        let mut addr = unsafe { addr.into_inner() };
+) -> LinuxResult<isize> {
+    // Safety: addr is used for mapping, and we won't directly access it.
+    let mut addr = unsafe { addr.into_inner() };
 
-        let curr = current();
-        let curr_ext = curr.task_ext();
-        let mut aspace = curr_ext.aspace.lock();
-        let permission_flags = MmapProt::from_bits_truncate(prot);
-        // TODO: check illegal flags for mmap
-        // An example is the flags contained none of MAP_PRIVATE, MAP_SHARED, or MAP_SHARED_VALIDATE.
-        let map_flags = MmapFlags::from_bits_truncate(flags);
-        let mut aligned_length = length;
+    let curr = current();
+    let curr_ext = curr.task_ext();
+    let mut aspace = curr_ext.aspace.lock();
+    let permission_flags = MmapProt::from_bits_truncate(prot);
+    // TODO: check illegal flags for mmap
+    // An example is the flags contained none of MAP_PRIVATE, MAP_SHARED, or MAP_SHARED_VALIDATE.
+    let map_flags = MmapFlags::from_bits_truncate(flags);
+    let mut aligned_length = length;
 
+    if addr.is_null() {
+        aligned_length = memory_addr::align_up_4k(aligned_length);
+    } else {
+        let start = addr as usize;
+        let mut end = start + aligned_length;
+        addr = memory_addr::align_down_4k(start) as *mut usize;
+        end = memory_addr::align_up_4k(end);
+        aligned_length = end - start;
+    }
+
+    info!(
+        "mmap: addr: {:?}, length: {:x?}, prot: {:?}, flags: {:?}, fd: {:?}, offset: {:?}",
+        addr, length, permission_flags, map_flags, fd, offset
+    );
+
+    let start_addr = if map_flags.contains(MmapFlags::MAP_FIXED) {
         if addr.is_null() {
-            aligned_length = memory_addr::align_up_4k(aligned_length);
-        } else {
-            let start = addr as usize;
-            let mut end = start + aligned_length;
-            addr = memory_addr::align_down_4k(start) as *mut usize;
-            end = memory_addr::align_up_4k(end);
-            aligned_length = end - start;
-        }
-
-        info!(
-            "mmap: addr: {:?}, length: {:x?}, prot: {:?}, flags: {:?}, fd: {:?}, offset: {:?}",
-            addr, length, permission_flags, map_flags, fd, offset
-        );
-
-        let start_addr = if map_flags.contains(MmapFlags::MAP_FIXED) {
-            if addr.is_null() {
-                return Err(LinuxError::EINVAL);
-            }
-            let dst_addr = VirtAddr::from(addr as usize);
-            aspace.unmap(dst_addr, aligned_length)?;
-            dst_addr
-        } else {
-            aspace
-                .find_free_area(
-                    VirtAddr::from(addr as usize),
-                    aligned_length,
-                    VirtAddrRange::new(aspace.base(), aspace.end()),
-                )
-                .or(aspace.find_free_area(
-                    aspace.base(),
-                    aligned_length,
-                    VirtAddrRange::new(aspace.base(), aspace.end()),
-                ))
-                .ok_or(LinuxError::ENOMEM)?
-        };
-
-        let populate = if fd == -1 {
-            false
-        } else {
-            !map_flags.contains(MmapFlags::MAP_ANONYMOUS)
-        };
-
-        aspace.map_alloc(
-            start_addr,
-            aligned_length,
-            permission_flags.into(),
-            populate,
-        )?;
-
-        if populate {
-            let file = arceos_posix_api::get_file_like(fd)?;
-            let file_size = file.stat()?.st_size as usize;
-            let file = file
-                .into_any()
-                .downcast::<arceos_posix_api::File>()
-                .map_err(|_| LinuxError::EBADF)?;
-            let file = file.inner().lock();
-            if offset < 0 || offset as usize >= file_size {
-                return Err(LinuxError::EINVAL);
-            }
-            let offset = offset as usize;
-            let length = core::cmp::min(length, file_size - offset);
-            let mut buf = vec![0u8; length];
-            file.read_at(offset as u64, &mut buf)?;
-            aspace.write(start_addr, &buf)?;
-        }
-        Ok(start_addr.as_usize())
-    })
-}
-
-pub fn sys_munmap(addr: UserPtr<usize>, mut length: usize) -> i32 {
-    syscall_body!(sys_munmap, {
-        // Safety: addr is used for mapping, and we won't directly access it.
-        let addr = unsafe { addr.into_inner() };
-
-        let curr = current();
-        let curr_ext = curr.task_ext();
-        let mut aspace = curr_ext.aspace.lock();
-        length = memory_addr::align_up_4k(length);
-        let start_addr = VirtAddr::from(addr as usize);
-        aspace.unmap(start_addr, length)?;
-        axhal::arch::flush_tlb(None);
-        Ok(0)
-    })
-}
-
-pub fn sys_mprotect(addr: UserPtr<usize>, mut length: usize, prot: i32) -> i32 {
-    syscall_body!(sys_mprotect, {
-        // Safety: addr is used for mapping, and we won't directly access it.
-        let addr = unsafe { addr.into_inner() };
-
-        // TODO: implement PROT_GROWSUP & PROT_GROWSDOWN
-        let Some(permission_flags) = MmapProt::from_bits(prot) else {
-            return Err(LinuxError::EINVAL);
-        };
-        if permission_flags.contains(MmapProt::PROT_GROWDOWN | MmapProt::PROT_GROWSUP) {
             return Err(LinuxError::EINVAL);
         }
+        let dst_addr = VirtAddr::from(addr as usize);
+        aspace.unmap(dst_addr, aligned_length)?;
+        dst_addr
+    } else {
+        aspace
+            .find_free_area(
+                VirtAddr::from(addr as usize),
+                aligned_length,
+                VirtAddrRange::new(aspace.base(), aspace.end()),
+            )
+            .or(aspace.find_free_area(
+                aspace.base(),
+                aligned_length,
+                VirtAddrRange::new(aspace.base(), aspace.end()),
+            ))
+            .ok_or(LinuxError::ENOMEM)?
+    };
 
-        let curr = current();
-        let curr_ext = curr.task_ext();
-        let mut aspace = curr_ext.aspace.lock();
-        length = memory_addr::align_up_4k(length);
-        let start_addr = VirtAddr::from(addr as usize);
-        aspace.protect(start_addr, length, permission_flags.into())?;
+    let populate = if fd == -1 {
+        false
+    } else {
+        !map_flags.contains(MmapFlags::MAP_ANONYMOUS)
+    };
 
-        Ok(0)
-    })
+    aspace.map_alloc(
+        start_addr,
+        aligned_length,
+        permission_flags.into(),
+        populate,
+    )?;
+
+    if populate {
+        let file = arceos_posix_api::get_file_like(fd)?;
+        let file_size = file.stat()?.st_size as usize;
+        let file = file
+            .into_any()
+            .downcast::<arceos_posix_api::File>()
+            .map_err(|_| LinuxError::EBADF)?;
+        let file = file.inner().lock();
+        if offset < 0 || offset as usize >= file_size {
+            return Err(LinuxError::EINVAL);
+        }
+        let offset = offset as usize;
+        let length = core::cmp::min(length, file_size - offset);
+        let mut buf = vec![0u8; length];
+        file.read_at(offset as u64, &mut buf)?;
+        aspace.write(start_addr, &buf)?;
+    }
+    Ok(start_addr.as_usize() as _)
+}
+
+#[apply(instrument)]
+pub fn sys_munmap(addr: UserPtr<usize>, length: usize) -> LinuxResult<isize> {
+    // Safety: addr is used for mapping, and we won't directly access it.
+    let addr = unsafe { addr.into_inner() };
+
+    let curr = current();
+    let curr_ext = curr.task_ext();
+    let mut aspace = curr_ext.aspace.lock();
+    let length = memory_addr::align_up_4k(length);
+    let start_addr = VirtAddr::from(addr as usize);
+    aspace.unmap(start_addr, length)?;
+    axhal::arch::flush_tlb(None);
+    Ok(0)
+}
+
+#[apply(instrument)]
+pub fn sys_mprotect(addr: UserPtr<usize>, length: usize, prot: i32) -> LinuxResult<isize> {
+    // Safety: addr is used for mapping, and we won't directly access it.
+    let addr = unsafe { addr.into_inner() };
+
+    // TODO: implement PROT_GROWSUP & PROT_GROWSDOWN
+    let Some(permission_flags) = MmapProt::from_bits(prot) else {
+        return Err(LinuxError::EINVAL);
+    };
+    if permission_flags.contains(MmapProt::PROT_GROWDOWN | MmapProt::PROT_GROWSUP) {
+        return Err(LinuxError::EINVAL);
+    }
+
+    let curr = current();
+    let curr_ext = curr.task_ext();
+    let mut aspace = curr_ext.aspace.lock();
+    let length = memory_addr::align_up_4k(length);
+    let start_addr = VirtAddr::from(addr as usize);
+    aspace.protect(start_addr, length, permission_flags.into())?;
+
+    Ok(0)
 }

--- a/src/syscall_imp/mod.rs
+++ b/src/syscall_imp/mod.rs
@@ -6,7 +6,7 @@ mod task;
 mod utils;
 
 use crate::task::{time_stat_from_kernel_to_user, time_stat_from_user_to_kernel};
-use axerrno::LinuxError;
+use axerrno::{LinuxError, LinuxResult};
 use axhal::{
     arch::TrapFrame,
     trap::{SYSCALL, register_trap_handler},
@@ -20,47 +20,43 @@ use self::sys::*;
 use self::task::*;
 use self::utils::*;
 
-/// Macro to unwrap a LinuxResult<_> into isize, returning -errno on error
-#[macro_export]
-macro_rules! syscall_unwrap {
-    ($expr:expr) => {
-        match $expr {
-            Ok(v) => v,
-            Err(e) => {
-                info!("syscall => {:?}", e);
-                return -e.code() as _;
-            }
-        }
-    };
-}
+macro_rules! instrument {(
+    $( #[$attr:meta] )*
+    $pub:vis
+    fn $fname:ident (
+        $( $arg_name:ident : $ArgTy:ty ),* $(,)?
+    ) -> $RetTy:ty
+    $body:block
+) => (
+    $( #[$attr] )*
+    #[allow(unused_parens)]
+    $pub
+    fn $fname (
+        $( $arg_name : $ArgTy ),*
+    ) -> $RetTy
+    {
+        /// Re-emit the original function definition, but as a scoped helper
+        $( #[$attr] )*
+        fn __original_func__ (
+            $($arg_name: $ArgTy),*
+        ) -> $RetTy
+        $body
 
-/// Macro to generate syscall body
-///
-/// It will receive a function which return Result<_, LinuxError> and convert it to
-/// the type which is specified by the caller.
-#[macro_export]
-macro_rules! syscall_body {
-    ($fn: ident, $($stmt: tt)*) => {{
-        #[allow(clippy::redundant_closure_call)]
-        let res = (|| -> axerrno::LinuxResult<_> { $($stmt)* })();
+        let res = __original_func__($($arg_name),*);
         match res {
-            Ok(_) | Err(axerrno::LinuxError::EAGAIN) => debug!(concat!(stringify!($fn), " => {:?}"),  res),
-            Err(_) => info!(concat!(stringify!($fn), " => {:?}"), res),
+            Ok(_) | Err(axerrno::LinuxError::EAGAIN) => debug!(concat!(stringify!($fname), " => {:?}"),  res),
+            Err(_) => info!(concat!(stringify!($fname), " => {:?}"), res),
         }
-        match res {
-            Ok(v) => v as _,
-            Err(e) => {
-                -e.code() as _
-            }
-        }
-    }};
-}
+        res
+    }
+)}
+pub(crate) use instrument;
 
 #[register_trap_handler(SYSCALL)]
 fn handle_syscall(tf: &TrapFrame, syscall_num: usize) -> isize {
     info!("Syscall {:?}", Sysno::from(syscall_num as u32));
     time_stat_from_user_to_kernel();
-    let ans = match Sysno::from(syscall_num as u32) {
+    let result: LinuxResult<isize> = match Sysno::from(syscall_num as u32) {
         Sysno::read => sys_read(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
         Sysno::write => sys_write(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
         Sysno::mmap => sys_mmap(
@@ -70,40 +66,40 @@ fn handle_syscall(tf: &TrapFrame, syscall_num: usize) -> isize {
             tf.arg3() as _,
             tf.arg4() as _,
             tf.arg5() as _,
-        ) as _,
-        Sysno::ioctl => sys_ioctl(tf.arg0() as _, tf.arg1() as _, tf.arg2().into()) as _,
+        ),
+        Sysno::ioctl => sys_ioctl(tf.arg0() as _, tf.arg1() as _, tf.arg2().into()),
         Sysno::writev => sys_writev(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
-        Sysno::sched_yield => sys_sched_yield() as isize,
-        Sysno::nanosleep => sys_nanosleep(tf.arg0().into(), tf.arg1().into()) as _,
-        Sysno::getpid => sys_getpid() as isize,
-        Sysno::getppid => sys_getppid() as isize,
+        Sysno::sched_yield => sys_sched_yield(),
+        Sysno::nanosleep => sys_nanosleep(tf.arg0().into(), tf.arg1().into()),
+        Sysno::getpid => sys_getpid(),
+        Sysno::getppid => sys_getppid(),
         Sysno::exit => sys_exit(tf.arg0() as _),
-        Sysno::gettimeofday => sys_get_time_of_day(tf.arg0().into()) as _,
-        Sysno::getcwd => sys_getcwd(tf.arg0().into(), tf.arg1() as _) as _,
-        Sysno::dup => sys_dup(tf.arg0() as _) as _,
-        Sysno::dup3 => sys_dup3(tf.arg0() as _, tf.arg1() as _) as _,
-        Sysno::fcntl => sys_fcntl(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _) as _,
+        Sysno::gettimeofday => sys_get_time_of_day(tf.arg0().into()),
+        Sysno::getcwd => sys_getcwd(tf.arg0().into(), tf.arg1() as _),
+        Sysno::dup => sys_dup(tf.arg0() as _),
+        Sysno::dup3 => sys_dup3(tf.arg0() as _, tf.arg1() as _),
+        Sysno::fcntl => sys_fcntl(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _),
         Sysno::clone => sys_clone(
             tf.arg0() as _,
             tf.arg1() as _,
             tf.arg2() as _,
             tf.arg3() as _,
             tf.arg4() as _,
-        ) as _,
-        Sysno::wait4 => sys_wait4(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _) as _,
-        Sysno::pipe2 => sys_pipe2(tf.arg0().into()) as _,
-        Sysno::close => sys_close(tf.arg0() as _) as _,
-        Sysno::chdir => sys_chdir(tf.arg0().into()) as _,
-        Sysno::mkdirat => sys_mkdirat(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _) as _,
-        Sysno::execve => sys_execve(tf.arg0().into(), tf.arg1().into(), tf.arg2().into()) as _,
+        ),
+        Sysno::wait4 => sys_wait4(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
+        Sysno::pipe2 => sys_pipe2(tf.arg0().into()),
+        Sysno::close => sys_close(tf.arg0() as _),
+        Sysno::chdir => sys_chdir(tf.arg0().into()),
+        Sysno::mkdirat => sys_mkdirat(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
+        Sysno::execve => sys_execve(tf.arg0().into(), tf.arg1().into(), tf.arg2().into()),
         Sysno::openat => sys_openat(
             tf.arg0() as _,
             tf.arg1().into(),
             tf.arg2() as _,
             tf.arg3() as _,
-        ) as _,
+        ),
         #[cfg(target_arch = "x86_64")]
-        Sysno::open => sys_open(tf.arg0().into(), tf.arg1() as _, tf.arg2() as _) as _,
+        Sysno::open => sys_open(tf.arg0().into(), tf.arg1() as _, tf.arg2() as _),
         Sysno::getdents64 => sys_getdents64(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
         Sysno::linkat => sys_linkat(
             tf.arg0() as _,
@@ -111,58 +107,59 @@ fn handle_syscall(tf: &TrapFrame, syscall_num: usize) -> isize {
             tf.arg2() as _,
             tf.arg3().into(),
             tf.arg4() as _,
-        ) as _,
+        ),
         Sysno::unlinkat => sys_unlinkat(tf.arg0() as _, tf.arg1().into(), tf.arg2() as _),
-        Sysno::uname => sys_uname(tf.arg0().into()) as _,
-        Sysno::fstat => sys_fstat(tf.arg0() as _, tf.arg1().into()) as _,
+        Sysno::uname => sys_uname(tf.arg0().into()),
+        Sysno::fstat => sys_fstat(tf.arg0() as _, tf.arg1().into()),
         #[cfg(target_arch = "x86_64")]
         Sysno::newfstatat => sys_fstatat(
             tf.arg0() as _,
             tf.arg1().into(),
             tf.arg2().into(),
             tf.arg3() as _,
-        ) as _,
+        ),
         #[cfg(not(target_arch = "x86_64"))]
         Sysno::fstatat => sys_fstatat(
             tf.arg0() as _,
             tf.arg1().into(),
             tf.arg2().into(),
             tf.arg3() as _,
-        ) as _,
+        ),
         Sysno::statx => sys_statx(
             tf.arg0() as _,
             tf.arg1().into(),
             tf.arg2() as _,
             tf.arg3() as _,
             tf.arg4().into(),
-        ) as _,
-        Sysno::munmap => sys_munmap(tf.arg0().into(), tf.arg1() as _) as _,
-        Sysno::mprotect => sys_mprotect(tf.arg0().into(), tf.arg1() as _, tf.arg2() as _) as _,
-        Sysno::times => sys_times(tf.arg0().into()) as _,
-        Sysno::brk => sys_brk(tf.arg0() as _) as _,
+        ),
+        Sysno::munmap => sys_munmap(tf.arg0().into(), tf.arg1() as _),
+        Sysno::mprotect => sys_mprotect(tf.arg0().into(), tf.arg1() as _, tf.arg2() as _),
+        Sysno::times => sys_times(tf.arg0().into()),
+        Sysno::brk => sys_brk(tf.arg0() as _),
         #[cfg(target_arch = "x86_64")]
         Sysno::arch_prctl => sys_arch_prctl(tf.arg0() as _, tf.arg1() as _),
         Sysno::set_tid_address => sys_set_tid_address(tf.arg0().into()),
-        Sysno::clock_gettime => sys_clock_gettime(tf.arg0() as _, tf.arg1().into()) as _,
+        Sysno::clock_gettime => sys_clock_gettime(tf.arg0() as _, tf.arg1().into()),
         Sysno::exit_group => sys_exit_group(tf.arg0() as _),
-        Sysno::getuid => sys_getuid() as _,
+        Sysno::getuid => sys_getuid(),
         Sysno::rt_sigprocmask => sys_rt_sigprocmask(
             tf.arg0() as _,
             tf.arg1().into(),
             tf.arg2().into(),
             tf.arg3() as _,
-        ) as _,
+        ),
         Sysno::rt_sigaction => sys_rt_sigaction(
             tf.arg0() as _,
             tf.arg1().into(),
             tf.arg2().into(),
             tf.arg3() as _,
-        ) as _,
+        ),
         _ => {
             warn!("Unimplemented syscall: {}", syscall_num);
             axtask::exit(LinuxError::ENOSYS as _)
         }
     };
+    let ans = result.unwrap_or_else(|err| -err.code() as _);
     time_stat_from_kernel_to_user();
     info!(
         "Syscall {:?} return {}",

--- a/src/syscall_imp/mod.rs
+++ b/src/syscall_imp/mod.rs
@@ -20,7 +20,7 @@ use self::sys::*;
 use self::task::*;
 use self::utils::*;
 
-macro_rules! instrument {(
+macro_rules! syscall_instrument {(
     $( #[$attr:meta] )*
     $pub:vis
     fn $fname:ident (
@@ -50,7 +50,7 @@ macro_rules! instrument {(
         res
     }
 )}
-pub(crate) use instrument;
+pub(crate) use syscall_instrument;
 
 #[register_trap_handler(SYSCALL)]
 fn handle_syscall(tf: &TrapFrame, syscall_num: usize) -> isize {

--- a/src/syscall_imp/signal.rs
+++ b/src/syscall_imp/signal.rs
@@ -1,23 +1,25 @@
 use core::ffi::c_void;
 
+use axerrno::LinuxResult;
+
 use crate::ptr::{UserConstPtr, UserPtr};
 
-pub(crate) fn sys_rt_sigprocmask(
+pub fn sys_rt_sigprocmask(
     _how: i32,
     _set: UserConstPtr<c_void>,
     _oldset: UserPtr<c_void>,
     _sigsetsize: usize,
-) -> isize {
+) -> LinuxResult<isize> {
     warn!("sys_rt_sigprocmask: not implemented");
-    0
+    Ok(0)
 }
 
-pub(crate) fn sys_rt_sigaction(
+pub fn sys_rt_sigaction(
     _signum: i32,
     _act: UserConstPtr<c_void>,
     _oldact: UserPtr<c_void>,
     _sigsetsize: usize,
-) -> isize {
+) -> LinuxResult<isize> {
     warn!("sys_rt_sigaction: not implemented");
-    0
+    Ok(0)
 }

--- a/src/syscall_imp/sys.rs
+++ b/src/syscall_imp/sys.rs
@@ -1,10 +1,9 @@
-use crate::{
-    ptr::{PtrWrapper, UserPtr},
-    syscall_body,
-};
+use axerrno::LinuxResult;
 
-pub fn sys_getuid() -> i32 {
-    0
+use crate::ptr::{PtrWrapper, UserPtr};
+
+pub fn sys_getuid() -> LinuxResult<isize> {
+    Ok(0)
 }
 
 #[repr(C)]
@@ -44,9 +43,7 @@ impl UtsName {
     }
 }
 
-pub fn sys_uname(name: UserPtr<UtsName>) -> i64 {
-    syscall_body!(sys_uname, {
-        unsafe { *name.get()? = UtsName::default() };
-        Ok(0)
-    })
+pub fn sys_uname(name: UserPtr<UtsName>) -> LinuxResult<isize> {
+    unsafe { *name.get()? = UtsName::default() };
+    Ok(0)
 }

--- a/src/syscall_imp/task/schedule.rs
+++ b/src/syscall_imp/task/schedule.rs
@@ -1,19 +1,15 @@
 use arceos_posix_api as api;
+use axerrno::LinuxResult;
 
-use crate::{
-    ptr::{PtrWrapper, UserConstPtr, UserPtr},
-    syscall_body,
-};
+use crate::ptr::{PtrWrapper, UserConstPtr, UserPtr};
 
-pub(crate) fn sys_sched_yield() -> i32 {
-    api::sys_sched_yield()
+pub fn sys_sched_yield() -> LinuxResult<isize> {
+    Ok(api::sys_sched_yield() as _)
 }
 
-pub(crate) fn sys_nanosleep(
+pub fn sys_nanosleep(
     req: UserConstPtr<api::ctypes::timespec>,
     rem: UserPtr<api::ctypes::timespec>,
-) -> i32 {
-    syscall_body!(sys_nanosleep, unsafe {
-        Ok(api::sys_nanosleep(req.get()?, rem.get()?))
-    })
+) -> LinuxResult<isize> {
+    unsafe { Ok(api::sys_nanosleep(req.get()?, rem.get()?) as _) }
 }

--- a/src/syscall_imp/task/thread.rs
+++ b/src/syscall_imp/task/thread.rs
@@ -1,17 +1,15 @@
-use core::{
-    ffi::{c_char, c_int},
-    ptr,
-};
+use core::{ffi::c_char, ptr};
 
 use alloc::vec::Vec;
-use axerrno::LinuxError;
+use axerrno::{LinuxError, LinuxResult};
 use axtask::{TaskExtRef, current, yield_now};
+use macro_rules_attribute::apply;
 use num_enum::TryFromPrimitive;
 
 use crate::{
     ctypes::{WaitFlags, WaitStatus},
     ptr::{PtrWrapper, UserConstPtr, UserPtr},
-    syscall_body,
+    syscall_imp::instrument,
     task::wait_pid,
 };
 
@@ -36,19 +34,17 @@ enum ArchPrctlCode {
     SetCpuid = 0x1012,
 }
 
-pub(crate) fn sys_getpid() -> i32 {
-    syscall_body!(sys_getpid, {
-        Ok(axtask::current().task_ext().proc_id as c_int)
-    })
+#[apply(instrument)]
+pub fn sys_getpid() -> LinuxResult<isize> {
+    Ok(axtask::current().task_ext().proc_id as _)
 }
 
-pub(crate) fn sys_getppid() -> i32 {
-    syscall_body!(sys_getppid, {
-        Ok(axtask::current().task_ext().get_parent() as c_int)
-    })
+#[apply(instrument)]
+pub fn sys_getppid() -> LinuxResult<isize> {
+    Ok(axtask::current().task_ext().get_parent() as _)
 }
 
-pub(crate) fn sys_exit(status: i32) -> ! {
+pub fn sys_exit(status: i32) -> ! {
     let curr = current();
     let clear_child_tid = curr.task_ext().clear_child_tid() as *mut i32;
     if !clear_child_tid.is_null() {
@@ -62,7 +58,7 @@ pub(crate) fn sys_exit(status: i32) -> ! {
     axtask::exit(status);
 }
 
-pub(crate) fn sys_exit_group(status: i32) -> ! {
+pub fn sys_exit_group(status: i32) -> ! {
     warn!("Temporarily replace sys_exit_group with sys_exit");
     axtask::exit(status);
 }
@@ -70,147 +66,142 @@ pub(crate) fn sys_exit_group(status: i32) -> ! {
 /// To set the clear_child_tid field in the task extended data.
 ///
 /// The set_tid_address() always succeeds
-pub(crate) fn sys_set_tid_address(tid_ptd: UserConstPtr<i32>) -> isize {
-    syscall_body!(sys_set_tid_address, {
-        let curr = current();
-        curr.task_ext()
-            .set_clear_child_tid(tid_ptd.address().as_ptr() as _);
-        Ok(curr.id().as_u64() as isize)
-    })
+#[apply(instrument)]
+pub fn sys_set_tid_address(tid_ptd: UserConstPtr<i32>) -> LinuxResult<isize> {
+    let curr = current();
+    curr.task_ext()
+        .set_clear_child_tid(tid_ptd.address().as_ptr() as _);
+    Ok(curr.id().as_u64() as isize)
 }
 
 #[cfg(target_arch = "x86_64")]
-pub(crate) fn sys_arch_prctl(code: i32, addr: u64) -> isize {
+#[apply(instrument)]
+pub fn sys_arch_prctl(code: i32, addr: u64) -> LinuxResult<isize> {
     use axerrno::LinuxError;
-    syscall_body!(sys_arch_prctl, {
-        match ArchPrctlCode::try_from(code) {
-            // TODO: check the legality of the address
-            Ok(ArchPrctlCode::SetFs) => {
-                unsafe {
-                    axhal::arch::write_thread_pointer(addr as usize);
-                }
-                Ok(0)
+    match ArchPrctlCode::try_from(code) {
+        // TODO: check the legality of the address
+        Ok(ArchPrctlCode::SetFs) => {
+            unsafe {
+                axhal::arch::write_thread_pointer(addr as usize);
             }
-            Ok(ArchPrctlCode::GetFs) => {
-                unsafe {
-                    *(addr as *mut u64) = axhal::arch::read_thread_pointer() as u64;
-                }
-                Ok(0)
-            }
-            Ok(ArchPrctlCode::SetGs) => {
-                unsafe {
-                    x86::msr::wrmsr(x86::msr::IA32_KERNEL_GSBASE, addr);
-                }
-                Ok(0)
-            }
-            Ok(ArchPrctlCode::GetGs) => {
-                unsafe {
-                    *(addr as *mut u64) = x86::msr::rdmsr(x86::msr::IA32_KERNEL_GSBASE);
-                }
-                Ok(0)
-            }
-            _ => Err(LinuxError::ENOSYS),
+            Ok(0)
         }
-    })
+        Ok(ArchPrctlCode::GetFs) => {
+            unsafe {
+                *(addr as *mut u64) = axhal::arch::read_thread_pointer() as u64;
+            }
+            Ok(0)
+        }
+        Ok(ArchPrctlCode::SetGs) => {
+            unsafe {
+                x86::msr::wrmsr(x86::msr::IA32_KERNEL_GSBASE, addr);
+            }
+            Ok(0)
+        }
+        Ok(ArchPrctlCode::GetGs) => {
+            unsafe {
+                *(addr as *mut u64) = x86::msr::rdmsr(x86::msr::IA32_KERNEL_GSBASE);
+            }
+            Ok(0)
+        }
+        _ => Err(LinuxError::ENOSYS),
+    }
 }
 
-pub(crate) fn sys_clone(
+#[apply(instrument)]
+pub fn sys_clone(
     flags: usize,
     user_stack: usize,
     ptid: usize,
     arg3: usize,
     arg4: usize,
-) -> isize {
-    syscall_body!(sys_clone, {
-        let tls = arg3;
-        let ctid = arg4;
+) -> LinuxResult<isize> {
+    let tls = arg3;
+    let ctid = arg4;
 
-        let stack = if user_stack == 0 {
-            None
-        } else {
-            Some(user_stack)
-        };
+    let stack = if user_stack == 0 {
+        None
+    } else {
+        Some(user_stack)
+    };
 
-        let curr_task = current();
+    let curr_task = current();
 
-        if let Ok(new_task_id) = curr_task
-            .task_ext()
-            .clone_task(flags, stack, ptid, tls, ctid)
-        {
-            Ok(new_task_id as isize)
-        } else {
-            Err(LinuxError::ENOMEM)
-        }
-    })
+    if let Ok(new_task_id) = curr_task
+        .task_ext()
+        .clone_task(flags, stack, ptid, tls, ctid)
+    {
+        Ok(new_task_id as isize)
+    } else {
+        Err(LinuxError::ENOMEM)
+    }
 }
 
-pub(crate) fn sys_wait4(pid: i32, exit_code_ptr: UserPtr<i32>, option: u32) -> isize {
+#[apply(instrument)]
+pub fn sys_wait4(pid: i32, exit_code_ptr: UserPtr<i32>, option: u32) -> LinuxResult<isize> {
     let option_flag = WaitFlags::from_bits(option).unwrap();
-    syscall_body!(sys_wait4, {
-        let exit_code_ptr = exit_code_ptr.nullable(UserPtr::get)?;
-        loop {
-            let answer = wait_pid(pid, exit_code_ptr.unwrap_or_else(ptr::null_mut));
-            match answer {
-                Ok(pid) => {
-                    return Ok(pid as isize);
-                }
-                Err(status) => match status {
-                    WaitStatus::NotExist => {
-                        return Err(LinuxError::ECHILD);
-                    }
-                    WaitStatus::Running => {
-                        if option_flag.contains(WaitFlags::WNOHANG) {
-                            return Ok(0);
-                        } else {
-                            yield_now();
-                        }
-                    }
-                    _ => {
-                        panic!("Shouldn't reach here!");
-                    }
-                },
+    let exit_code_ptr = exit_code_ptr.nullable(UserPtr::get)?;
+    loop {
+        let answer = wait_pid(pid, exit_code_ptr.unwrap_or_else(ptr::null_mut));
+        match answer {
+            Ok(pid) => {
+                return Ok(pid as isize);
             }
+            Err(status) => match status {
+                WaitStatus::NotExist => {
+                    return Err(LinuxError::ECHILD);
+                }
+                WaitStatus::Running => {
+                    if option_flag.contains(WaitFlags::WNOHANG) {
+                        return Ok(0);
+                    } else {
+                        yield_now();
+                    }
+                }
+                _ => {
+                    panic!("Shouldn't reach here!");
+                }
+            },
         }
-    })
+    }
 }
 
+#[apply(instrument)]
 pub fn sys_execve(
     path: UserConstPtr<c_char>,
     argv: UserConstPtr<usize>,
     envp: UserConstPtr<usize>,
-) -> isize {
-    syscall_body!(sys_execve, {
-        let path_str = path.get_as_str()?;
+) -> LinuxResult<isize> {
+    let path_str = path.get_as_str()?;
 
-        let args = argv
-            .get_as_null_terminated()?
-            .iter()
-            .map(|arg| {
-                UserConstPtr::<c_char>::from(*arg)
-                    .get_as_str()
-                    .map(Into::into)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        let envs = envp
-            .get_as_null_terminated()?
-            .iter()
-            .map(|env| {
-                UserConstPtr::<c_char>::from(*env)
-                    .get_as_str()
-                    .map(Into::into)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+    let args = argv
+        .get_as_null_terminated()?
+        .iter()
+        .map(|arg| {
+            UserConstPtr::<c_char>::from(*arg)
+                .get_as_str()
+                .map(Into::into)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let envs = envp
+        .get_as_null_terminated()?
+        .iter()
+        .map(|env| {
+            UserConstPtr::<c_char>::from(*env)
+                .get_as_str()
+                .map(Into::into)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
-        info!(
-            "execve: path: {:?}, args: {:?}, envs: {:?}",
-            path_str, args, envs
-        );
+    info!(
+        "execve: path: {:?}, args: {:?}, envs: {:?}",
+        path_str, args, envs
+    );
 
-        if let Err(e) = crate::task::exec(path_str, &args, &envs) {
-            error!("Failed to exec: {:?}", e);
-            return Err::<isize, _>(LinuxError::ENOSYS);
-        }
+    if let Err(e) = crate::task::exec(path_str, &args, &envs) {
+        error!("Failed to exec: {:?}", e);
+        return Err::<isize, _>(LinuxError::ENOSYS);
+    }
 
-        unreachable!("execve should never return");
-    })
+    unreachable!("execve should never return");
 }

--- a/src/syscall_imp/task/thread.rs
+++ b/src/syscall_imp/task/thread.rs
@@ -9,7 +9,7 @@ use num_enum::TryFromPrimitive;
 use crate::{
     ctypes::{WaitFlags, WaitStatus},
     ptr::{PtrWrapper, UserConstPtr, UserPtr},
-    syscall_imp::instrument,
+    syscall_imp::syscall_instrument,
     task::wait_pid,
 };
 
@@ -34,12 +34,12 @@ enum ArchPrctlCode {
     SetCpuid = 0x1012,
 }
 
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_getpid() -> LinuxResult<isize> {
     Ok(axtask::current().task_ext().proc_id as _)
 }
 
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_getppid() -> LinuxResult<isize> {
     Ok(axtask::current().task_ext().get_parent() as _)
 }
@@ -66,7 +66,7 @@ pub fn sys_exit_group(status: i32) -> ! {
 /// To set the clear_child_tid field in the task extended data.
 ///
 /// The set_tid_address() always succeeds
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_set_tid_address(tid_ptd: UserConstPtr<i32>) -> LinuxResult<isize> {
     let curr = current();
     curr.task_ext()
@@ -75,7 +75,7 @@ pub fn sys_set_tid_address(tid_ptd: UserConstPtr<i32>) -> LinuxResult<isize> {
 }
 
 #[cfg(target_arch = "x86_64")]
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_arch_prctl(code: i32, addr: u64) -> LinuxResult<isize> {
     use axerrno::LinuxError;
     match ArchPrctlCode::try_from(code) {
@@ -108,7 +108,7 @@ pub fn sys_arch_prctl(code: i32, addr: u64) -> LinuxResult<isize> {
     }
 }
 
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_clone(
     flags: usize,
     user_stack: usize,
@@ -137,7 +137,7 @@ pub fn sys_clone(
     }
 }
 
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_wait4(pid: i32, exit_code_ptr: UserPtr<i32>, option: u32) -> LinuxResult<isize> {
     let option_flag = WaitFlags::from_bits(option).unwrap();
     let exit_code_ptr = exit_code_ptr.nullable(UserPtr::get)?;
@@ -166,7 +166,7 @@ pub fn sys_wait4(pid: i32, exit_code_ptr: UserPtr<i32>, option: u32) -> LinuxRes
     }
 }
 
-#[apply(instrument)]
+#[apply(syscall_instrument)]
 pub fn sys_execve(
     path: UserConstPtr<c_char>,
     argv: UserConstPtr<usize>,

--- a/src/syscall_imp/utils/time.rs
+++ b/src/syscall_imp/utils/time.rs
@@ -1,38 +1,30 @@
-use core::ffi::c_int;
-
 use arceos_posix_api::{self as api, ctypes::timeval};
+use axerrno::LinuxResult;
 use axhal::time::{monotonic_time_nanos, nanos_to_ticks};
 
 use crate::{
     ctypes::Tms,
     ptr::{PtrWrapper, UserPtr},
-    syscall_body,
     task::time_stat_output,
 };
 
-pub(crate) fn sys_clock_gettime(clock_id: i32, tp: UserPtr<api::ctypes::timespec>) -> i32 {
-    syscall_body!(sys_clock_gettime, unsafe {
-        Ok(api::sys_clock_gettime(clock_id, tp.get()?))
-    })
+pub fn sys_clock_gettime(clock_id: i32, tp: UserPtr<api::ctypes::timespec>) -> LinuxResult<isize> {
+    unsafe { Ok(api::sys_clock_gettime(clock_id, tp.get()?) as _) }
 }
 
-pub(crate) fn sys_get_time_of_day(ts: UserPtr<timeval>) -> c_int {
-    syscall_body!(sys_get_time_of_day, unsafe {
-        Ok(api::sys_get_time_of_day(ts.get()?))
-    })
+pub fn sys_get_time_of_day(ts: UserPtr<timeval>) -> LinuxResult<isize> {
+    unsafe { Ok(api::sys_get_time_of_day(ts.get()?) as _) }
 }
 
-pub fn sys_times(tms: UserPtr<Tms>) -> isize {
-    syscall_body!(sys_times, {
-        let (_, utime_us, _, stime_us) = time_stat_output();
-        unsafe {
-            *tms.get()? = Tms {
-                tms_utime: utime_us,
-                tms_stime: stime_us,
-                tms_cutime: utime_us,
-                tms_cstime: stime_us,
-            }
+pub fn sys_times(tms: UserPtr<Tms>) -> LinuxResult<isize> {
+    let (_, utime_us, _, stime_us) = time_stat_output();
+    unsafe {
+        *tms.get()? = Tms {
+            tms_utime: utime_us,
+            tms_stime: stime_us,
+            tms_cutime: utime_us,
+            tms_cstime: stime_us,
         }
-        Ok(nanos_to_ticks(monotonic_time_nanos()) as isize)
-    })
+    }
+    Ok(nanos_to_ticks(monotonic_time_nanos()) as _)
 }


### PR DESCRIPTION
This PR unifies syscall style. It enforces all syscall to return `LinuxResult<isize>`, and replaced `syscall_body` with `#[apply(instrument)]`.

This PR also fixes some incorrect errorcode (e.g. `sys_mkdirat` used to return `-1` for any error).