### PR TITLE
Adapt to changes to AddrSpace in ArceOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "log",
  "memory_addr",
  "memory_set",
+ "page_table_multiarch",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,8 +1122,7 @@ checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 [[package]]
 name = "page_table_entry"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c097d641745a066856a26eed6e486d4430bb3e32c94f1203ea09c63239b360a0"
+source = "git+https://github.com/Mivik/page_table_multiarch.git?rev=19ededd#19ededdb806ab3b22efb4880661790524fa421a5"
 dependencies = [
  "aarch64-cpu",
  "bitflags 2.9.0",
@@ -1134,8 +1133,7 @@ dependencies = [
 [[package]]
 name = "page_table_multiarch"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4647889585d29762d747be0916d6d28db72967a697d142be86f187a6b496832a"
+source = "git+https://github.com/Mivik/page_table_multiarch.git?rev=19ededd#19ededdb806ab3b22efb4880661790524fa421a5"
 dependencies = [
  "log",
  "memory_addr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ axns = { git = "https://github.com/oscomp/arceos.git", features = ["thread-local
 
 [patch.crates-io]
 syscalls = { git = "https://github.com/jasonwhite/syscalls.git", rev = "92624de"}
+page_table_multiarch = { git = "https://github.com/Mivik/page_table_multiarch.git", rev = "19ededd" }
+page_table_entry = { git = "https://github.com/Mivik/page_table_multiarch.git", rev = "19ededd" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 x86 = "0.52"

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,23 +24,32 @@ use axmm::{AddrSpace, kernel_aspace};
 use axsync::Mutex;
 use memory_addr::VirtAddr;
 
-/// Creates a new address space for user processes.
-fn new_user_aspace() -> AxResult<AddrSpace> {
-    let mut aspace = AddrSpace::new_empty(
+fn new_user_aspace_empty() -> AxResult<AddrSpace> {
+    AddrSpace::new_empty(
         VirtAddr::from_usize(axconfig::plat::USER_SPACE_BASE),
         axconfig::plat::USER_SPACE_SIZE,
-    )?;
+    )
+}
+
+/// If the target architecture requires it, the kernel portion of the address
+/// space will be copied to the user address space.
+fn copy_from_kernel(aspace: &mut AddrSpace) -> AxResult {
     if !cfg!(target_arch = "aarch64") && !cfg!(target_arch = "loongarch64") {
         // ARMv8 (aarch64) and LoongArch64 use separate page tables for user space
         // (aarch64: TTBR0_EL1, LoongArch64: PGDL), so there is no need to copy the
         // kernel portion to the user page table.
         aspace.copy_mappings_from(&kernel_aspace().lock())?;
     }
-    Ok(aspace)
+    Ok(())
 }
 
 fn run_user_app(args: &[String], envs: &[String]) -> Option<i32> {
-    let mut uspace = new_user_aspace().expect("Failed to create user address space");
+    let mut uspace = new_user_aspace_empty()
+        .and_then(|mut it| {
+            copy_from_kernel(&mut it)?;
+            Ok(it)
+        })
+        .expect("Failed to create user address space");
 
     let path = arceos_posix_api::FilePath::new(&args[0]).expect("Invalid file path");
     axfs::api::set_current_dir(path.parent().unwrap()).expect("Failed to set current dir");

--- a/src/task.rs
+++ b/src/task.rs
@@ -6,12 +6,12 @@ use alloc::{
 use arceos_posix_api::FD_TABLE;
 use axerrno::{AxError, AxResult};
 use axfs::{CURRENT_DIR, CURRENT_DIR_PATH};
-use memory_addr::VirtAddrRange;
 use core::{
     alloc::Layout,
     cell::UnsafeCell,
     sync::atomic::{AtomicU64, Ordering},
 };
+use memory_addr::VirtAddrRange;
 use spin::Once;
 
 use crate::ctypes::{CloneFlags, TimeStat, WaitStatus};
@@ -19,7 +19,7 @@ use axhal::{
     arch::{TrapFrame, UspaceContext},
     time::{NANOS_PER_MICROS, NANOS_PER_SEC, monotonic_time_nanos},
 };
-use axmm::{kernel_aspace, AddrSpace};
+use axmm::{AddrSpace, kernel_aspace};
 use axns::{AxNamespace, AxNamespaceIf};
 use axsync::Mutex;
 use axtask::{AxTaskRef, TaskExtRef, TaskInner, current};

--- a/src/task.rs
+++ b/src/task.rs
@@ -14,7 +14,10 @@ use core::{
 use memory_addr::VirtAddrRange;
 use spin::Once;
 
-use crate::ctypes::{CloneFlags, TimeStat, WaitStatus};
+use crate::{
+    copy_from_kernel,
+    ctypes::{CloneFlags, TimeStat, WaitStatus},
+};
 use axhal::{
     arch::{TrapFrame, UspaceContext},
     time::{NANOS_PER_MICROS, NANOS_PER_SEC, monotonic_time_nanos},
@@ -101,7 +104,8 @@ impl TaskExt {
 
         let current_task = current();
         let mut current_aspace = current_task.task_ext().aspace.lock();
-        let new_aspace = current_aspace.clone_or_err()?;
+        let mut new_aspace = current_aspace.clone_or_err()?;
+        copy_from_kernel(&mut new_aspace)?;
         new_task
             .ctx_mut()
             .set_page_table_root(new_aspace.page_table_root());


### PR DESCRIPTION
New changes to `AddrSpace` in ArceOS removed `new_user_aspace` and handled control to us. This PR handles AddrSpace recycling properly in `TaskExt::drop`.