### PR TITLE
Add signal functionalities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,6 +1466,7 @@ dependencies = [
  "axhal",
  "axlog",
  "axprocess",
+ "axsignal",
  "axsync",
  "axtask",
  "linkme",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "axsignal"
 version = "0.1.0"
-source = "git+https://github.com/Starry-OS/axsignal.git#aa1f5fa13aac905d2685e0495cec65b3efbc47ce"
+source = "git+https://github.com/Starry-OS/axsignal.git#7f393263dc088c194c25b9dda7d717300f61730e"
 dependencies = [
  "axconfig",
  "axerrno",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "axsignal"
 version = "0.1.0"
-source = "git+https://github.com/Starry-OS/axsignal.git#7352c08332cd67f84ea9dbb401859925cd59474a"
+source = "git+https://github.com/Starry-OS/axsignal.git?rev=b5b6089#b5b6089c40a989ff8ae434ec32ea388b7a9d7a11"
 dependencies = [
  "axconfig",
  "axerrno",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "axsignal"
 version = "0.1.0"
-source = "git+https://github.com/Starry-OS/axsignal.git#7f393263dc088c194c25b9dda7d717300f61730e"
+source = "git+https://github.com/Starry-OS/axsignal.git#7352c08332cd67f84ea9dbb401859925cd59474a"
 dependencies = [
  "axconfig",
  "axerrno",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "axsignal"
 version = "0.1.0"
-source = "git+https://github.com/Starry-OS/axsignal.git#36a7bb40ed2d5a71f435d19727bd497c8f8641ff"
+source = "git+https://github.com/Starry-OS/axsignal.git#99e66eb8e32049bd04dcb9df469af9b6a4d1defa"
 dependencies = [
  "axconfig",
  "axerrno",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,11 +447,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "axsignal"
+version = "0.1.0"
+source = "git+https://github.com/Starry-OS/axsignal.git#36a7bb40ed2d5a71f435d19727bd497c8f8641ff"
+dependencies = [
+ "axconfig",
+ "axerrno",
+ "axhal",
+ "axtask",
+ "bitflags 2.9.0",
+ "cfg-if",
+ "derive_more",
+ "linux-raw-sys 0.9.4",
+ "lock_api",
+ "log",
+ "strum_macros",
+]
+
+[[package]]
 name = "axsync"
 version = "0.1.0"
 dependencies = [
  "axtask",
  "kspin",
+ "lock_api",
 ]
 
 [[package]]
@@ -644,6 +663,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b396d1f76d455557e1218ec8066ae14bba60b4b36ecd55577ba979f5db7ecaa"
 
 [[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cpumask"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +747,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3983b127f13995e68c1e29071e5d115cd96f215ccb5e6812e3728cd6f92653b3"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1436,9 +1486,11 @@ dependencies = [
  "axhal",
  "axlog",
  "axprocess",
+ "axsignal",
  "axsync",
  "axtask",
  "bitflags 2.9.0",
+ "linkme",
  "linux-raw-sys 0.9.4",
  "macro_rules_attribute",
  "memory_addr",
@@ -1460,6 +1512,7 @@ dependencies = [
  "axmm",
  "axns",
  "axprocess",
+ "axsignal",
  "axsync",
  "axtask",
  "crate_interface",
@@ -1484,6 +1537,19 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "svgbobdoc"
@@ -1587,10 +1653,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "axsignal"
 version = "0.1.0"
-source = "git+https://github.com/Starry-OS/axsignal.git#99e66eb8e32049bd04dcb9df469af9b6a4d1defa"
+source = "git+https://github.com/Starry-OS/axsignal.git#a6b672563160cfd4636bd83b67c5623a1f2bbbc7"
 dependencies = [
  "axconfig",
  "axerrno",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "axsignal"
 version = "0.1.0"
-source = "git+https://github.com/Starry-OS/axsignal.git#a6b672563160cfd4636bd83b67c5623a1f2bbbc7"
+source = "git+https://github.com/Starry-OS/axsignal.git#aa1f5fa13aac905d2685e0495cec65b3efbc47ce"
 dependencies = [
  "axconfig",
  "axerrno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ axsync = { git = "https://github.com/oscomp/arceos.git" }
 axtask = { git = "https://github.com/oscomp/arceos.git" }
 
 axprocess = { git = "https://github.com/Starry-OS/axprocess.git" }
-axsignal = { git = "https://github.com/Starry-OS/axsignal.git" }
+axsignal = { git = "https://github.com/Starry-OS/axsignal.git", rev = "b5b6089" }
 
 axerrno = "0.1"
 bitflags = "2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ axsync = { git = "https://github.com/oscomp/arceos.git" }
 axtask = { git = "https://github.com/oscomp/arceos.git" }
 
 axprocess = { git = "https://github.com/Starry-OS/axprocess.git" }
+axsignal = { git = "https://github.com/Starry-OS/axsignal.git" }
 
 axerrno = "0.1"
 bitflags = "2.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ axtask.workspace = true
 arceos_posix_api.workspace = true
 
 axprocess.workspace = true
+axsignal.workspace = true
 
 axerrno.workspace = true
 linkme.workspace = true

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -16,9 +16,11 @@ axtask.workspace = true
 arceos_posix_api.workspace = true
 
 axprocess.workspace = true
+axsignal.workspace = true
 
 axerrno.workspace = true
 bitflags.workspace = true
+linkme.workspace = true
 linux-raw-sys.workspace = true
 memory_addr.workspace = true
 

--- a/api/src/imp/signal.rs
+++ b/api/src/imp/signal.rs
@@ -1,25 +1,209 @@
-use core::ffi::c_void;
+use axerrno::{LinuxError, LinuxResult};
+use axprocess::{Pid, Process, ProcessGroup, Thread};
+use linux_raw_sys::general::{SI_USER, SIG_BLOCK, SIG_SETMASK, SIG_UNBLOCK, kernel_sigaction};
+use starry_core::task::{ProcessData, ThreadData, get_process, get_process_group, processes};
 
-use axerrno::LinuxResult;
+use crate::ptr::{PtrWrapper, UserConstPtr, UserPtr};
 
-use crate::ptr::{UserConstPtr, UserPtr};
+use axhal::{
+    arch::TrapFrame,
+    trap::{POST_TRAP, register_trap_handler},
+};
+use axsignal::{SignalInfo, SignalOSAction, SignalSet, Signo};
+use axtask::{TaskExtRef, current};
+
+use super::do_exit;
+
+#[register_trap_handler(POST_TRAP)]
+fn post_trap_callback(tf: &mut TrapFrame, from_user: bool) {
+    if !from_user {
+        return;
+    }
+
+    let curr = current();
+    let Some((sig, os_action)) = curr.task_ext().thread_data().signal.check_signals(tf, None)
+    else {
+        return;
+    };
+
+    let signo = sig.signo();
+    match os_action {
+        SignalOSAction::Terminate => {
+            do_exit(128 + signo as i32, true);
+        }
+        SignalOSAction::CoreDump => {
+            // TODO: implement core dump
+            do_exit(128 + signo as i32, true);
+        }
+        SignalOSAction::Stop => {
+            // TODO: implement stop
+            do_exit(1, true);
+        }
+        SignalOSAction::Continue => {
+            // TODO: implement continue
+        }
+        SignalOSAction::Handler => {
+            // do nothing
+        }
+    }
+}
+
+fn check_sigset_size(size: usize) -> LinuxResult<()> {
+    if size != size_of::<SignalSet>() {
+        return Err(LinuxError::EINVAL);
+    }
+    Ok(())
+}
 
 pub fn sys_rt_sigprocmask(
-    _how: i32,
-    _set: UserConstPtr<c_void>,
-    _oldset: UserPtr<c_void>,
-    _sigsetsize: usize,
+    how: i32,
+    set: UserConstPtr<SignalSet>,
+    oldset: UserPtr<SignalSet>,
+    sigsetsize: usize,
 ) -> LinuxResult<isize> {
-    warn!("sys_rt_sigprocmask: not implemented");
+    check_sigset_size(sigsetsize)?;
+
+    current()
+        .task_ext()
+        .thread_data()
+        .signal
+        .with_blocked_mut::<LinuxResult<_>>(|blocked| {
+            if let Some(oldset) = oldset.nullable(UserPtr::get)? {
+                unsafe { *oldset = *blocked };
+            }
+
+            if let Some(set) = set.nullable(UserConstPtr::get)? {
+                let set = unsafe { *set };
+                match how as u32 {
+                    SIG_BLOCK => *blocked |= set,
+                    SIG_UNBLOCK => *blocked &= !set,
+                    SIG_SETMASK => *blocked = set,
+                    _ => return Err(LinuxError::EINVAL),
+                }
+            }
+            Ok(())
+        })?;
+
     Ok(0)
 }
 
 pub fn sys_rt_sigaction(
-    _signum: i32,
-    _act: UserConstPtr<c_void>,
-    _oldact: UserPtr<c_void>,
-    _sigsetsize: usize,
+    signo: i32,
+    act: UserConstPtr<kernel_sigaction>,
+    oldact: UserPtr<kernel_sigaction>,
+    sigsetsize: usize,
 ) -> LinuxResult<isize> {
-    warn!("sys_rt_sigaction: not implemented");
+    check_sigset_size(sigsetsize)?;
+
+    let signo = Signo::from_repr(signo as u8).ok_or(LinuxError::EINVAL)?;
+    if matches!(signo, Signo::SIGKILL | Signo::SIGSTOP) {
+        return Err(LinuxError::EINVAL);
+    }
+
+    let curr = current();
+    curr.task_ext()
+        .process_data()
+        .signal
+        .with_action_mut::<LinuxResult<_>>(signo, |action| {
+            if let Some(oldact) = oldact.nullable(UserPtr::get)? {
+                action.to_ctype(unsafe { &mut *oldact });
+            }
+            if let Some(act) = act.nullable(UserConstPtr::get)? {
+                *action = unsafe { (*act).try_into()? };
+            }
+            Ok(())
+        })?;
+
     Ok(0)
+}
+
+pub fn sys_rt_sigpending(set: UserPtr<SignalSet>, sigsetsize: usize) -> LinuxResult<isize> {
+    check_sigset_size(sigsetsize)?;
+    let set = set.get()?;
+    unsafe {
+        *set = current().task_ext().thread_data().signal.pending();
+    }
+    Ok(0)
+}
+
+pub fn send_signal_thread(thr: &Thread, sig: SignalInfo) -> bool {
+    info!("Send signal {:?} to thread {}", sig.signo(), thr.tid());
+    if let Some(thr) = thr.data::<ThreadData>() {
+        thr.signal.send_signal(sig);
+        true
+    } else {
+        false
+    }
+}
+pub fn send_signal_process(proc: &Process, sig: SignalInfo) -> bool {
+    info!("Send signal {:?} to process {}", sig.signo(), proc.pid());
+    if let Some(proc) = proc.data::<ProcessData>() {
+        proc.signal.send_signal(sig);
+        true
+    } else {
+        false
+    }
+}
+pub fn send_signal_process_group(pg: &ProcessGroup, sig: SignalInfo) -> usize {
+    info!(
+        "Send signal {:?} to process group {}",
+        sig.signo(),
+        pg.pgid()
+    );
+    let mut count = 0;
+    for proc in pg.processes() {
+        count += send_signal_process(&proc, sig.clone()) as usize;
+    }
+    count
+}
+
+fn make_siginfo(signo: u32, code: u32) -> LinuxResult<Option<SignalInfo>> {
+    if signo == 0 {
+        return Ok(None);
+    }
+    let signo = Signo::from_repr(signo as u8).ok_or(LinuxError::EINVAL)?;
+    Ok(Some(SignalInfo::new(signo, code)))
+}
+
+pub fn sys_kill(pid: i32, sig: u32) -> LinuxResult<isize> {
+    let Some(sig) = make_siginfo(sig, SI_USER)? else {
+        // TODO: should also check permissions
+        return Ok(0);
+    };
+
+    let curr = current();
+    let mut result = 0usize;
+    match pid {
+        1.. => {
+            let proc = get_process(pid as Pid)?;
+            send_signal_process(&proc, sig);
+            result += 1;
+        }
+        0 => {
+            let pg = curr.task_ext().thread.process().group();
+            result += send_signal_process_group(&pg, sig);
+        }
+        -1 => {
+            for proc in processes() {
+                if proc.is_init() {
+                    // init process
+                    continue;
+                }
+                send_signal_process(&proc, sig.clone());
+                result += 1;
+            }
+        }
+        ..-1 => {
+            let pg = get_process_group((-pid) as Pid)?;
+            result += send_signal_process_group(&pg, sig);
+        }
+    }
+
+    Ok(result as isize)
+}
+
+pub fn sys_rt_sigreturn(tf: &mut TrapFrame) -> LinuxResult<isize> {
+    let curr = current();
+    curr.task_ext().thread_data().signal.restore(tf);
+    Ok(tf.retval() as isize)
 }

--- a/api/src/imp/signal.rs
+++ b/api/src/imp/signal.rs
@@ -229,11 +229,11 @@ pub fn sys_tgkill(tgid: Pid, tid: Pid, signo: u32) -> LinuxResult<isize> {
         return Ok(0);
     };
 
-    send_signal_thread(get_thread_checked(tgid, tid)?.as_ref(), sig)?;
+    send_signal_thread(find_thread_in_group(tgid, tid)?.as_ref(), sig)?;
     Ok(0)
 }
 
-fn get_thread_checked(tgid: Pid, tid: Pid) -> LinuxResult<Arc<Thread>> {
+fn find_thread_in_group(tgid: Pid, tid: Pid) -> LinuxResult<Arc<Thread>> {
     let thr = get_thread(tid)?;
     if thr.process().pid() != tgid {
         return Err(LinuxError::ESRCH);
@@ -278,7 +278,7 @@ pub fn sys_rt_tgsigqueueinfo(
     check_sigset_size(sigsetsize)?;
 
     let sig = make_queue_signal_info(tgid, signo, sig)?;
-    send_signal_thread(get_thread_checked(tgid, tid)?.as_ref(), sig)?;
+    send_signal_thread(find_thread_in_group(tgid, tid)?.as_ref(), sig)?;
     Ok(0)
 }
 

--- a/api/src/imp/signal.rs
+++ b/api/src/imp/signal.rs
@@ -337,7 +337,7 @@ pub fn sys_rt_sigsuspend(
         .signal
         .with_blocked_mut(|blocked| mem::replace(blocked, set));
 
-    tf.set_retval((-LinuxError::EINTR.code() as isize) as usize);
+    tf.set_retval(-LinuxError::EINTR.code() as usize);
 
     loop {
         if check_signals(tf, Some(old_blocked)) {

--- a/api/src/imp/task/clone.rs
+++ b/api/src/imp/task/clone.rs
@@ -110,14 +110,6 @@ pub fn sys_clone(
     if stack != 0 {
         new_uctx.set_sp(stack);
     }
-    // Skip current instruction
-    // FIXME: we should do this in arceos before calling `handle_syscall`.
-    // See: https://github.com/oscomp/arceos/commit/13ff3f58bd825c37ea5eef3393a4f8c0bb5b4f41
-    #[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))]
-    {
-        let new_uctx_ip = new_uctx.ip();
-        new_uctx.set_ip(new_uctx_ip + 4);
-    }
     if flags.contains(CloneFlags::SETTLS) {
         warn!("sys_clone: CLONE_SETTLS is not supported yet");
     }

--- a/api/src/imp/task/clone.rs
+++ b/api/src/imp/task/clone.rs
@@ -9,10 +9,7 @@ use axtask::{TaskExtRef, current};
 use bitflags::bitflags;
 use linux_raw_sys::general::*;
 use macro_rules_attribute::apply;
-use starry_core::{
-    mm::copy_from_kernel,
-    task::{ProcessData, TaskExt, ThreadData, add_thread_to_table, new_user_task},
-};
+use starry_core::{mm::copy_from_kernel, task::{add_thread_to_table, new_user_task, ProcessData, TaskExt, ThreadData}};
 
 use crate::{
     ptr::{PtrWrapper, UserPtr},
@@ -205,7 +202,7 @@ pub fn sys_clone(
         &builder.data(process_data).build()
     };
 
-    let thread_data = ThreadData::new();
+    let thread_data = ThreadData::new(process.data().unwrap());
     if flags.contains(CloneFlags::CHILD_CLEARTID) {
         thread_data.set_clear_child_tid(child_tid);
     }

--- a/api/src/imp/task/clone.rs
+++ b/api/src/imp/task/clone.rs
@@ -9,7 +9,10 @@ use axtask::{TaskExtRef, current};
 use bitflags::bitflags;
 use linux_raw_sys::general::*;
 use macro_rules_attribute::apply;
-use starry_core::{mm::copy_from_kernel, task::{add_thread_to_table, new_user_task, ProcessData, TaskExt, ThreadData}};
+use starry_core::{
+    mm::copy_from_kernel,
+    task::{ProcessData, TaskExt, ThreadData, add_thread_to_table, new_user_task},
+};
 
 use crate::{
     ptr::{PtrWrapper, UserPtr},

--- a/api/src/imp/task/execve.rs
+++ b/api/src/imp/task/execve.rs
@@ -5,7 +5,7 @@ use axerrno::{LinuxError, LinuxResult};
 use axhal::arch::UspaceContext;
 use axtask::{TaskExtRef, current};
 use macro_rules_attribute::apply;
-use starry_core::mm::load_user_app;
+use starry_core::mm::{load_user_app, map_trampoline};
 
 use crate::{ptr::UserConstPtr, syscall_instrument};
 
@@ -52,6 +52,7 @@ pub fn sys_execve(
 
     let mut aspace = curr_ext.process_data().aspace.lock();
     aspace.unmap_user_areas()?;
+    map_trampoline(&mut aspace)?;
     axhal::arch::flush_tlb(None);
 
     let (entry_point, user_stack_base) =

--- a/api/src/imp/task/exit.rs
+++ b/api/src/imp/task/exit.rs
@@ -1,7 +1,13 @@
 use axprocess::Pid;
+use axsignal::{SignalInfo, Signo};
 use axtask::{TaskExtRef, current};
+use linux_raw_sys::general::SI_KERNEL;
+use starry_core::task::ProcessData;
 
-use crate::ptr::{PtrWrapper, UserPtr};
+use crate::{
+    ptr::{PtrWrapper, UserPtr},
+    send_signal_process, send_signal_thread,
+};
 
 pub fn do_exit(exit_code: i32, group_exit: bool) -> ! {
     let curr = current();
@@ -18,13 +24,25 @@ pub fn do_exit(exit_code: i32, group_exit: bool) -> ! {
 
     let process = thread.process();
     if thread.exit(exit_code) {
-        // TODO: send exit signal to parent
+        process.exit();
+        if let Some(parent) = process.parent() {
+            if let Some(signo) = process.data::<ProcessData>().and_then(|it| it.exit_signal) {
+                let _ = send_signal_process(&parent, SignalInfo::new(signo, SI_KERNEL));
+            }
+            if let Some(data) = parent.data::<ProcessData>() {
+                data.child_exit_wq.notify_all(false)
+            }
+        }
+
         process.exit();
         // TODO: clear namespace resources
     }
     if group_exit && !process.is_group_exited() {
         process.group_exit();
-        // TODO: send SIGKILL to other threads
+        let sig = SignalInfo::new(Signo::SIGKILL, SI_KERNEL);
+        for thr in process.threads() {
+            let _ = send_signal_thread(&thr, sig.clone());
+        }
     }
     axtask::exit(exit_code)
 }

--- a/api/src/imp/task/exit.rs
+++ b/api/src/imp/task/exit.rs
@@ -27,7 +27,7 @@ pub fn do_exit(exit_code: i32, group_exit: bool) -> ! {
         process.exit();
         if let Some(parent) = process.parent() {
             if let Some(signo) = process.data::<ProcessData>().and_then(|it| it.exit_signal) {
-                let _ = send_signal_process(&parent, SignalInfo::new(signo, SI_KERNEL));
+                let _ = send_signal_process(&parent, SignalInfo::new(signo, SI_KERNEL as _));
             }
             if let Some(data) = parent.data::<ProcessData>() {
                 data.child_exit_wq.notify_all(false)
@@ -39,7 +39,7 @@ pub fn do_exit(exit_code: i32, group_exit: bool) -> ! {
     }
     if group_exit && !process.is_group_exited() {
         process.group_exit();
-        let sig = SignalInfo::new(Signo::SIGKILL, SI_KERNEL);
+        let sig = SignalInfo::new(Signo::SIGKILL, SI_KERNEL as _);
         for thr in process.threads() {
             let _ = send_signal_thread(&thr, sig.clone());
         }

--- a/apps/libc/c/signal/signal.c
+++ b/apps/libc/c/signal/signal.c
@@ -167,7 +167,7 @@ int main() {
   test_sigaction();
   test_sigprocmask();
   test_sigkill_stop();
-  // test_sigwait();
-  // test_sigsuspend();
+  test_sigwait();
+  test_sigsuspend();
   return 0;
 }

--- a/apps/libc/c/signal/signal.c
+++ b/apps/libc/c/signal/signal.c
@@ -167,7 +167,7 @@ int main() {
   test_sigaction();
   test_sigprocmask();
   test_sigkill_stop();
-  //   test_sigwait();
-  //   test_sigsuspend();
+  // test_sigwait();
+  // test_sigsuspend();
   return 0;
 }

--- a/apps/libc/c/signal/signal.c
+++ b/apps/libc/c/signal/signal.c
@@ -166,7 +166,7 @@ int main() {
   test_term();
   test_sigaction();
   test_sigprocmask();
-  //   test_sigkill_stop();
+  test_sigkill_stop();
   //   test_sigwait();
   //   test_sigsuspend();
   return 0;

--- a/apps/libc/c/signal/signal.c
+++ b/apps/libc/c/signal/signal.c
@@ -1,0 +1,173 @@
+#include <errno.h>
+#include <signal.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+void test_term() {
+  if (fork() == 0) {
+    kill(getpid(), SIGTERM);
+    while (1)
+      ;
+  }
+  wait(NULL);
+  puts("test_term ok");
+}
+
+static void signal_handler(int signum) {
+  static int count = 0;
+  count++;
+  printf("Received signal %d, count=%d\n", signum, count);
+  if (count > 1) {
+    return;
+  }
+  // This should be blocked and won't cause recursion
+  kill(getpid(), SIGTERM);
+  printf("End, count=%d\n", count);
+}
+
+void test_sigaction() {
+  struct sigaction sa = {0};
+  sa.sa_handler = signal_handler;
+  sigaction(SIGTERM, &sa, NULL);
+  kill(getpid(), SIGTERM);
+  puts("test_sigaction ok1");
+
+  sa.sa_handler = (void (*)(int))1;
+  sigaction(SIGTERM, &sa, NULL);
+  kill(getpid(), SIGTERM);
+  puts("test_sigaction ok2");
+
+  sa.sa_handler = (void (*)(int))0;
+  sigaction(SIGTERM, &sa, NULL);
+}
+
+void test_sigprocmask() {
+  sigset_t set, set2;
+  sigemptyset(&set);
+  sigaddset(&set, SIGTERM);
+  sigprocmask(SIG_BLOCK, &set, NULL);
+  kill(getpid(), SIGTERM);
+
+  sigpending(&set2);
+  if (sigismember(&set2, SIGTERM)) {
+    puts("test_sigprocmask ok1");
+  }
+
+  // Ignore SIGTERM for once
+  struct sigaction sa = {0};
+  sa.sa_handler = (void (*)(int))1;
+  sigaction(SIGTERM, &sa, NULL);
+
+  sigdelset(&set, SIGTERM);
+  sigprocmask(SIG_SETMASK, &set, NULL);
+
+  sigpending(&set2);
+  if (!sigismember(&set2, SIGTERM)) {
+    puts("test_sigprocmask ok2");
+  }
+
+  sa.sa_handler = (void (*)(int))0;
+  sigaction(SIGTERM, &sa, NULL);
+}
+
+void test_sigkill_stop() {
+  struct sigaction sa = {0};
+  sa.sa_handler = signal_handler;
+  if (sigaction(SIGKILL, &sa, NULL) < 0) {
+    puts("test_sigkill_stop ok1");
+  }
+  if (sigaction(SIGSTOP, &sa, NULL) < 0) {
+    puts("test_sigkill_stop ok2");
+  }
+}
+
+void test_sigwait() {
+  int pid = fork();
+  if (pid == 0) {
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGTERM);
+    sigprocmask(SIG_BLOCK, &set, NULL);
+    int sig;
+    sigwait(&set, &sig);
+    if (sig == SIGTERM) {
+      puts("test_sigwait ok1");
+    }
+    exit(0);
+  }
+  sleep(1);
+  kill(pid, SIGTERM);
+  wait(NULL);
+  puts("test_sigwait ok2");
+
+  sigset_t set;
+  sigemptyset(&set);
+  sigaddset(&set, SIGTERM);
+  sigprocmask(SIG_BLOCK, &set, NULL);
+  struct timespec ts = {1, 0};
+  if (sigtimedwait(&set, NULL, &ts) < 0 && errno == EAGAIN) {
+    puts("test_sigwait ok3");
+  }
+  sigprocmask(SIG_UNBLOCK, &set, NULL);
+}
+
+static void signal_handler2(int signum) { puts("test_sigsuspend ok1"); }
+static void signal_handler3(int signum) { puts("test_sigsuspend ok3"); }
+void test_sigsuspend() {
+  int pid = fork();
+  if (pid == 0) {
+    struct sigaction sa = {0};
+    sa.sa_handler = signal_handler2;
+    sigaction(SIGUSR1, &sa, NULL);
+
+    sigset_t set;
+    sigemptyset(&set);
+    sigaddset(&set, SIGTERM);
+    sigsuspend(&set);
+    // SIGTERM is handled immediately after so this won't run
+    // To ensure it, we check this return code below
+    exit(0);
+  }
+  sleep(1);
+  kill(pid, SIGTERM);
+  sleep(1);
+  kill(pid, SIGUSR1);
+  int status;
+  wait(&status);
+  if (status != 0) {
+    puts("test_sigsuspend ok2");
+  }
+
+  pid = fork();
+  if (pid == 0) {
+    // Ignore SIGTERM
+    struct sigaction sa = {0};
+    sa.sa_handler = (void (*)(int))1;
+    sigaction(SIGTERM, &sa, NULL);
+
+    sa.sa_handler = signal_handler3;
+    sigaction(SIGUSR1, &sa, NULL);
+
+    sigset_t set;
+    sigemptyset(&set);
+    sigsuspend(&set);
+    exit(0);
+  }
+  sleep(1);
+  kill(pid, SIGTERM); // SIGTERM is ignored so sigsuspend won't unblock
+  sleep(1);
+  kill(pid, SIGUSR1);
+}
+
+int main() {
+  test_term();
+  test_sigaction();
+  test_sigprocmask();
+  //   test_sigkill_stop();
+  //   test_sigwait();
+  //   test_sigsuspend();
+  return 0;
+}

--- a/apps/libc/c/sleep/sleep.c
+++ b/apps/libc/c/sleep/sleep.c
@@ -2,8 +2,8 @@
 #include <unistd.h>
 int main()
 {
-    printf("Sleeping for 5 seconds...\n");
-    sleep(5);
+    printf("Sleeping for 2 seconds...\n");
+    sleep(2);
     printf("Done!\n");
     return 0;
 }

--- a/apps/libc/expect_off.out
+++ b/apps/libc/expect_off.out
@@ -14,3 +14,5 @@ test_sigaction ok1
 test_sigaction ok2
 test_sigprocmask ok1
 test_sigprocmask ok2
+test_sigkill_stop ok1
+test_sigkill_stop ok2

--- a/apps/libc/expect_off.out
+++ b/apps/libc/expect_off.out
@@ -16,3 +16,9 @@ test_sigprocmask ok1
 test_sigprocmask ok2
 test_sigkill_stop ok1
 test_sigkill_stop ok2
+test_sigwait ok1
+test_sigwait ok2
+test_sigwait ok3
+test_sigsuspend ok1
+test_sigsuspend ok2
+test_sigsuspend ok3

--- a/apps/libc/expect_off.out
+++ b/apps/libc/expect_off.out
@@ -3,5 +3,14 @@ build_mode = release
 log_level = off
 
 Hello, World!
-Sleeping for 5 seconds...
+Sleeping for 2 seconds...
 Done!
+
+test_term ok
+Received signal 15, count=1
+End, count=1
+Received signal 15, count=2
+test_sigaction ok1
+test_sigaction ok2
+test_sigprocmask ok1
+test_sigprocmask ok2

--- a/apps/libc/testcase_list
+++ b/apps/libc/testcase_list
@@ -1,2 +1,3 @@
 helloworld_c
 sleep_c
+signal_c

--- a/configs/aarch64.toml
+++ b/configs/aarch64.toml
@@ -18,3 +18,6 @@ user-heap-size = 0x1_0000
 
 # The size of the kernel stack.
 kernel-stack-size = 0x40000
+
+# The address of signal trampoline.
+signal-trampoline = 0x4001_0000

--- a/configs/dummy.toml
+++ b/configs/dummy.toml
@@ -54,6 +54,8 @@ user-heap-base = 0        # uint
 # The size of the user heap.
 user-heap-size = 0          # uint
 
+# The address of signal trampoline.
+signal-trampoline = 0
 
 #
 # Device specifications

--- a/configs/loongarch64.toml
+++ b/configs/loongarch64.toml
@@ -18,3 +18,6 @@ user-heap-size = 0x1_0000
 
 # The size of the kernel stack.
 kernel-stack-size = 0x40000
+
+# The address of signal trampoline.
+signal-trampoline = 0x4001_0000

--- a/configs/riscv64.toml
+++ b/configs/riscv64.toml
@@ -18,3 +18,6 @@ user-heap-size = 0x1_0000
 
 # The size of the kernel stack.
 kernel-stack-size = 0x40000
+
+# The address of signal trampoline.
+signal-trampoline = 0x4001_0000

--- a/configs/x86_64.toml
+++ b/configs/x86_64.toml
@@ -18,3 +18,6 @@ user-heap-size = 0x1_0000
 
 # The size of the kernel stack.
 kernel-stack-size = 0x40000
+
+# The address of signal trampoline.
+signal-trampoline = 0x4001_0000

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,6 +17,7 @@ axsync.workspace = true
 axtask.workspace = true
 
 axprocess.workspace = true
+axsignal.workspace = true
 
 axerrno.workspace = true
 linkme.workspace = true

--- a/core/src/mm.rs
+++ b/core/src/mm.rs
@@ -29,8 +29,7 @@ pub fn copy_from_kernel(aspace: &mut AddrSpace) -> AxResult {
 
 /// Map the signal trampoline to the user address space.
 pub fn map_trampoline(aspace: &mut AddrSpace) -> AxResult {
-    let signal_trampoline_paddr =
-        virt_to_phys(axsignal::arch::signal_trampoline_address().into());
+    let signal_trampoline_paddr = virt_to_phys(axsignal::arch::signal_trampoline_address().into());
     aspace.map_linear(
         axconfig::plat::SIGNAL_TRAMPOLINE.into(),
         signal_trampoline_paddr,

--- a/core/src/mm.rs
+++ b/core/src/mm.rs
@@ -2,7 +2,7 @@ use core::ffi::CStr;
 
 use alloc::{string::String, vec};
 use axerrno::{AxError, AxResult};
-use axhal::paging::MappingFlags;
+use axhal::{mem::virt_to_phys, paging::MappingFlags};
 use axmm::{AddrSpace, kernel_aspace};
 use kernel_elf_parser::{AuxvEntry, ELFParser, app_stack_region};
 use memory_addr::{MemoryAddr, PAGE_SIZE_4K, VirtAddr};
@@ -24,6 +24,19 @@ pub fn copy_from_kernel(aspace: &mut AddrSpace) -> AxResult {
         // kernel portion to the user page table.
         aspace.copy_mappings_from(&kernel_aspace().lock())?;
     }
+    Ok(())
+}
+
+/// Map the signal trampoline to the user address space.
+pub fn map_trampoline(aspace: &mut AddrSpace) -> AxResult {
+    let signal_trampoline_paddr =
+        virt_to_phys(axsignal::arch::signal_trampoline_address().into());
+    aspace.map_linear(
+        axconfig::plat::SIGNAL_TRAMPOLINE.into(),
+        signal_trampoline_paddr,
+        PAGE_SIZE_4K,
+        MappingFlags::READ | MappingFlags::EXECUTE | MappingFlags::USER,
+    )?;
     Ok(())
 }
 

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -329,22 +329,27 @@ pub fn add_thread_to_table(thread: &Arc<Thread>) {
     session_table.insert(session.sid(), &session);
 }
 
+/// Lists all processes.
 pub fn processes() -> Vec<Arc<Process>> {
     PROCESS_TABLE.read().values().collect()
 }
 
+/// Finds the thread with the given TID.
 pub fn get_thread(tid: Pid) -> LinuxResult<Arc<Thread>> {
     THREAD_TABLE.read().get(&tid).ok_or(LinuxError::ESRCH)
 }
+/// Finds the process with the given PID.
 pub fn get_process(pid: Pid) -> LinuxResult<Arc<Process>> {
     PROCESS_TABLE.read().get(&pid).ok_or(LinuxError::ESRCH)
 }
+/// Finds the process group with the given PGID.
 pub fn get_process_group(pgid: Pid) -> LinuxResult<Arc<ProcessGroup>> {
     PROCESS_GROUP_TABLE
         .read()
         .get(&pgid)
         .ok_or(LinuxError::ESRCH)
 }
+/// Finds the session with the given SID.
 pub fn get_session(sid: Pid) -> LinuxResult<Arc<Session>> {
     SESSION_TABLE.read().get(&sid).ok_or(LinuxError::ESRCH)
 }

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -20,7 +20,7 @@ use axns::{AxNamespace, AxNamespaceIf};
 use axprocess::{Pid, Process, ProcessGroup, Session, Thread};
 use axsignal::{
     Signo,
-    api::{ProcessSignalManager, ThreadSignalManager},
+    api::{ProcessSignalManager, SignalActions, ThreadSignalManager},
 };
 use axsync::{Mutex, RawMutex};
 use axtask::{TaskExtRef, TaskInner, WaitQueue, current};
@@ -196,7 +196,12 @@ pub struct ProcessData {
 }
 
 impl ProcessData {
-    pub fn new(exe_path: String, aspace: Arc<Mutex<AddrSpace>>, exit_signal: Option<Signo>) -> Self {
+    pub fn new(
+        exe_path: String,
+        aspace: Arc<Mutex<AddrSpace>>,
+        signal_actions: Arc<Mutex<SignalActions>>,
+        exit_signal: Option<Signo>,
+    ) -> Self {
         Self {
             exe_path: RwLock::new(exe_path),
             aspace,
@@ -207,7 +212,10 @@ impl ProcessData {
             child_exit_wq: WaitQueue::new(),
             exit_signal,
 
-            signal: Arc::new(ProcessSignalManager::new(axconfig::plat::SIGNAL_TRAMPOLINE)),
+            signal: Arc::new(ProcessSignalManager::new(
+                signal_actions,
+                axconfig::plat::SIGNAL_TRAMPOLINE,
+            )),
         }
     }
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -3,6 +3,7 @@ use arceos_posix_api::FD_TABLE;
 use axfs::{CURRENT_DIR, CURRENT_DIR_PATH, api::set_current_dir};
 use axhal::arch::UspaceContext;
 use axprocess::{Pid, init_proc};
+use axsignal::Signo;
 use axsync::Mutex;
 use starry_core::{
     mm::{copy_from_kernel, load_user_app, map_trampoline, new_user_aspace_empty},
@@ -30,7 +31,8 @@ pub fn run_user_app(args: &[String], envs: &[String]) -> Option<i32> {
     let mut task = new_user_task(name, uctx, None);
     task.ctx_mut().set_page_table_root(uspace.page_table_root());
 
-    let process_data = ProcessData::new(exe_path, Arc::new(Mutex::new(uspace)));
+    let process_data =
+        ProcessData::new(exe_path, Arc::new(Mutex::new(uspace)), Some(Signo::SIGCHLD));
 
     FD_TABLE
         .deref_from(&process_data.ns)

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -31,8 +31,12 @@ pub fn run_user_app(args: &[String], envs: &[String]) -> Option<i32> {
     let mut task = new_user_task(name, uctx, None);
     task.ctx_mut().set_page_table_root(uspace.page_table_root());
 
-    let process_data =
-        ProcessData::new(exe_path, Arc::new(Mutex::new(uspace)), Some(Signo::SIGCHLD));
+    let process_data = ProcessData::new(
+        exe_path,
+        Arc::new(Mutex::new(uspace)),
+        Arc::default(),
+        Some(Signo::SIGCHLD),
+    );
 
     FD_TABLE
         .deref_from(&process_data.ns)

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -135,6 +135,7 @@ fn handle_syscall(tf: &mut TrapFrame, syscall_num: usize) -> isize {
         Sysno::kill => sys_kill(tf.arg0() as _, tf.arg1() as _),
         Sysno::tkill => sys_tkill(tf.arg0() as _, tf.arg1() as _),
         Sysno::tgkill => sys_tgkill(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _),
+        Sysno::sigaltstack => sys_sigaltstack(tf.arg0().into(), tf.arg1().into()),
         _ => {
             warn!("Unimplemented syscall: {}", sysno);
             Err(LinuxError::ENOSYS)

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -135,6 +135,19 @@ fn handle_syscall(tf: &mut TrapFrame, syscall_num: usize) -> isize {
         Sysno::kill => sys_kill(tf.arg0() as _, tf.arg1() as _),
         Sysno::tkill => sys_tkill(tf.arg0() as _, tf.arg1() as _),
         Sysno::tgkill => sys_tgkill(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _),
+        Sysno::rt_sigqueueinfo => sys_rt_sigqueueinfo(
+            tf.arg0() as _,
+            tf.arg1() as _,
+            tf.arg2().into(),
+            tf.arg3() as _,
+        ),
+        Sysno::rt_tgsigqueueinfo => sys_rt_tgsigqueueinfo(
+            tf.arg0() as _,
+            tf.arg1() as _,
+            tf.arg2() as _,
+            tf.arg3().into(),
+            tf.arg4() as _,
+        ),
         Sysno::sigaltstack => sys_sigaltstack(tf.arg0().into(), tf.arg1().into()),
         _ => {
             warn!("Unimplemented syscall: {}", sysno);

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -125,6 +125,13 @@ fn handle_syscall(tf: &mut TrapFrame, syscall_num: usize) -> isize {
         ),
         Sysno::rt_sigpending => sys_rt_sigpending(tf.arg0().into(), tf.arg1() as _),
         Sysno::rt_sigreturn => sys_rt_sigreturn(tf),
+        Sysno::rt_sigtimedwait => sys_rt_sigtimedwait(
+            tf.arg0().into(),
+            tf.arg1().into(),
+            tf.arg2().into(),
+            tf.arg3() as _,
+        ),
+        Sysno::rt_sigsuspend => sys_rt_sigsuspend(tf, tf.arg0().into(), tf.arg1() as _),
         Sysno::kill => sys_kill(tf.arg0() as _, tf.arg1() as _),
         _ => {
             warn!("Unimplemented syscall: {}", sysno);

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -8,7 +8,7 @@ use starry_core::task::{time_stat_from_kernel_to_user, time_stat_from_user_to_ke
 use syscalls::Sysno;
 
 #[register_trap_handler(SYSCALL)]
-fn handle_syscall(tf: &TrapFrame, syscall_num: usize) -> isize {
+fn handle_syscall(tf: &mut TrapFrame, syscall_num: usize) -> isize {
     let sysno = Sysno::from(syscall_num as u32);
     info!("Syscall {}", sysno);
     time_stat_from_user_to_kernel();
@@ -123,6 +123,9 @@ fn handle_syscall(tf: &TrapFrame, syscall_num: usize) -> isize {
             tf.arg2().into(),
             tf.arg3() as _,
         ),
+        Sysno::rt_sigpending => sys_rt_sigpending(tf.arg0().into(), tf.arg1() as _),
+        Sysno::rt_sigreturn => sys_rt_sigreturn(tf),
+        Sysno::kill => sys_kill(tf.arg0() as _, tf.arg1() as _),
         _ => {
             warn!("Unimplemented syscall: {}", sysno);
             Err(LinuxError::ENOSYS)

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -133,6 +133,8 @@ fn handle_syscall(tf: &mut TrapFrame, syscall_num: usize) -> isize {
         ),
         Sysno::rt_sigsuspend => sys_rt_sigsuspend(tf, tf.arg0().into(), tf.arg1() as _),
         Sysno::kill => sys_kill(tf.arg0() as _, tf.arg1() as _),
+        Sysno::tkill => sys_tkill(tf.arg0() as _, tf.arg1() as _),
+        Sysno::tgkill => sys_tgkill(tf.arg0() as _, tf.arg1() as _, tf.arg2() as _),
         _ => {
             warn!("Unimplemented syscall: {}", sysno);
             Err(LinuxError::ENOSYS)


### PR DESCRIPTION
## Description

Depends on https://github.com/oscomp/arceos/pull/34

This PR implements signal functionalities, including:

- Various syscalls (See `src/syscall.rs`)
- Sending signal on process exit (`eixt_signal`)
- A test covering the majority of signal syscalls
- Enhancement on current `clone` implementation
