### PR TITLE
Add futex support

### DIFF
--- a/api/src/imp/futex.rs
+++ b/api/src/imp/futex.rs
@@ -1,0 +1,91 @@
+use alloc::sync::Arc;
+use arceos_posix_api::ctypes::timespec;
+use axerrno::{LinuxError, LinuxResult};
+use axtask::{TaskExtRef, WaitQueue, current};
+use linux_raw_sys::general::{
+    FUTEX_CMD_MASK, FUTEX_CMP_REQUEUE, FUTEX_REQUEUE, FUTEX_WAIT, FUTEX_WAKE,
+};
+
+use crate::ptr::{PtrWrapper, UserConstPtr, UserPtr};
+
+fn new_futex() -> Arc<WaitQueue> {
+    Arc::new(WaitQueue::new())
+}
+
+pub fn sys_futex(
+    uaddr: UserConstPtr<u32>,
+    futex_op: u32,
+    value: u32,
+    timeout: UserConstPtr<timespec>,
+    uaddr2: UserPtr<u32>,
+    value3: u32,
+) -> LinuxResult<isize> {
+    info!("futex {:?} {} {}", uaddr.address(), futex_op, value);
+
+    let curr = current();
+    let futex_table = &curr.task_ext().process_data().futex_table;
+
+    let addr = uaddr.address().as_usize();
+    let command = futex_op & (FUTEX_CMD_MASK as u32);
+    match command {
+        FUTEX_WAIT => {
+            if unsafe { uaddr.get()?.read() } != value {
+                return Err(LinuxError::EAGAIN);
+            }
+            let wq = futex_table
+                .lock()
+                .entry(addr)
+                .or_insert_with(new_futex)
+                .clone();
+
+            if let Some(timeout) = timeout.nullable(UserConstPtr::get)? {
+                wq.wait_timeout(unsafe { *timeout }.into());
+            } else {
+                wq.wait();
+            }
+
+            Ok(0)
+        }
+        FUTEX_WAKE => {
+            let wq = futex_table.lock().get(&addr).cloned();
+            let mut count = 0;
+            if let Some(wq) = wq {
+                for _ in 0..value {
+                    if !wq.notify_one(false) {
+                        break;
+                    }
+                    count += 1;
+                }
+            }
+            axtask::yield_now();
+            Ok(count)
+        }
+        FUTEX_REQUEUE | FUTEX_CMP_REQUEUE => {
+            if command == FUTEX_CMP_REQUEUE && unsafe { uaddr.get()?.read() } != value3 {
+                return Err(LinuxError::EAGAIN);
+            }
+            let value2 = timeout.address().as_usize() as u32;
+
+            let mut futex_table = futex_table.lock();
+            let wq = futex_table.get(&addr).cloned();
+            let wq2 = futex_table
+                .entry(uaddr2.address().as_usize())
+                .or_insert_with(new_futex)
+                .clone();
+            drop(futex_table);
+
+            let mut count = 0;
+            if let Some(wq) = wq {
+                for _ in 0..value {
+                    if !wq.notify_one(false) {
+                        break;
+                    }
+                    count += 1;
+                }
+                count += wq.requeue(value2 as usize, &wq2) as isize;
+            }
+            Ok(count)
+        }
+        _ => Err(LinuxError::ENOSYS),
+    }
+}

--- a/api/src/imp/futex.rs
+++ b/api/src/imp/futex.rs
@@ -72,7 +72,9 @@ pub fn sys_futex(
                     }
                     count += 1;
                 }
-                count += wq.requeue(value2 as usize, &wq2) as isize;
+                if count == value as isize {
+                    count += wq.requeue(value2 as usize, &wq2) as isize;
+                }
             }
             Ok(count)
         }

--- a/api/src/imp/futex.rs
+++ b/api/src/imp/futex.rs
@@ -1,16 +1,11 @@
-use alloc::sync::Arc;
 use arceos_posix_api::ctypes::timespec;
 use axerrno::{LinuxError, LinuxResult};
-use axtask::{TaskExtRef, WaitQueue, current};
+use axtask::{TaskExtRef, current};
 use linux_raw_sys::general::{
     FUTEX_CMD_MASK, FUTEX_CMP_REQUEUE, FUTEX_REQUEUE, FUTEX_WAIT, FUTEX_WAKE,
 };
 
 use crate::ptr::{PtrWrapper, UserConstPtr, UserPtr};
-
-fn new_futex() -> Arc<WaitQueue> {
-    Arc::new(WaitQueue::new())
-}
 
 pub fn sys_futex(
     uaddr: UserConstPtr<u32>,
@@ -32,11 +27,7 @@ pub fn sys_futex(
             if unsafe { uaddr.get()?.read() } != value {
                 return Err(LinuxError::EAGAIN);
             }
-            let wq = futex_table
-                .lock()
-                .entry(addr)
-                .or_insert_with(new_futex)
-                .clone();
+            let wq = futex_table.lock().get_or_insert(addr);
 
             if let Some(timeout) = timeout.nullable(UserConstPtr::get)? {
                 wq.wait_timeout(unsafe { *timeout }.into());
@@ -47,7 +38,7 @@ pub fn sys_futex(
             Ok(0)
         }
         FUTEX_WAKE => {
-            let wq = futex_table.lock().get(&addr).cloned();
+            let wq = futex_table.lock().get(addr);
             let mut count = 0;
             if let Some(wq) = wq {
                 for _ in 0..value {
@@ -67,10 +58,9 @@ pub fn sys_futex(
             let value2 = timeout.address().as_usize() as u32;
 
             let mut futex_table = futex_table.lock();
-            let wq = futex_table.get(&addr).cloned();
+            let wq = futex_table.get(addr);
             let wq2 = futex_table
-                .entry(uaddr2.address().as_usize())
-                .or_insert_with(new_futex)
+                .get_or_insert(uaddr2.address().as_usize())
                 .clone();
             drop(futex_table);
 

--- a/api/src/imp/mod.rs
+++ b/api/src/imp/mod.rs
@@ -1,8 +1,9 @@
 mod fs;
+mod futex;
 mod mm;
 mod signal;
 mod sys;
 mod task;
 mod utils;
 
-pub use self::{fs::*, mm::*, signal::*, sys::*, task::*, utils::*};
+pub use self::{fs::*, futex::*, mm::*, signal::*, sys::*, task::*, utils::*};

--- a/api/src/imp/task/exit.rs
+++ b/api/src/imp/task/exit.rs
@@ -19,8 +19,7 @@ pub fn do_exit(exit_code: i32, group_exit: bool) -> ! {
     let clear_child_tid = UserPtr::<Pid>::from(curr_ext.thread_data().clear_child_tid());
     if let Ok(clear_tid) = clear_child_tid.get() {
         unsafe { clear_tid.write(0) };
-        if let Some(futex) = curr
-            .task_ext()
+        if let Some(futex) = curr_ext
             .process_data()
             .futex_table
             .lock()

--- a/api/src/imp/task/exit.rs
+++ b/api/src/imp/task/exit.rs
@@ -23,8 +23,7 @@ pub fn do_exit(exit_code: i32, group_exit: bool) -> ! {
             .process_data()
             .futex_table
             .lock()
-            .get(&(clear_tid as *const _ as usize))
-            .cloned()
+            .get(clear_tid as *const _ as usize)
         {
             futex.notify_one(false);
         }

--- a/api/src/imp/task/exit.rs
+++ b/api/src/imp/task/exit.rs
@@ -19,7 +19,17 @@ pub fn do_exit(exit_code: i32, group_exit: bool) -> ! {
     let clear_child_tid = UserPtr::<Pid>::from(curr_ext.thread_data().clear_child_tid());
     if let Ok(clear_tid) = clear_child_tid.get() {
         unsafe { clear_tid.write(0) };
-        // TODO: wake up threads, which are blocked by futex, and waiting for the address pointed by clear_child_tid
+        if let Some(futex) = curr
+            .task_ext()
+            .process_data()
+            .futex_table
+            .lock()
+            .get(&(clear_tid as *const _ as usize))
+            .cloned()
+        {
+            futex.notify_one(false);
+        }
+        axtask::yield_now();
     }
 
     let process = thread.process();

--- a/core/src/futex.rs
+++ b/core/src/futex.rs
@@ -1,0 +1,53 @@
+use core::ops::Deref;
+
+use alloc::{collections::btree_map::BTreeMap, sync::Arc};
+use axtask::{TaskExtRef, WaitQueue, current};
+
+/// A table mapping memory addresses to futex wait queues.
+#[derive(Default)]
+pub struct FutexTable(BTreeMap<usize, Arc<WaitQueue>>);
+impl FutexTable {
+    /// Gets the wait queue associated with the given address.
+    pub fn get(&self, addr: usize) -> Option<WaitQueueGuard> {
+        let wq = self.0.get(&addr).cloned()?;
+        Some(WaitQueueGuard {
+            key: addr,
+            inner: wq,
+        })
+    }
+
+    /// Gets the wait queue associated with the given address, or inserts a a
+    /// new one if it doesn't exist.
+    pub fn get_or_insert(&mut self, addr: usize) -> WaitQueueGuard {
+        let wq = self
+            .0
+            .entry(addr)
+            .or_insert_with(|| Arc::new(WaitQueue::new()));
+        WaitQueueGuard {
+            key: addr,
+            inner: wq.clone(),
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct WaitQueueGuard {
+    key: usize,
+    inner: Arc<WaitQueue>,
+}
+impl Deref for WaitQueueGuard {
+    type Target = Arc<WaitQueue>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+impl Drop for WaitQueueGuard {
+    fn drop(&mut self) {
+        let curr = current();
+        let mut table = curr.task_ext().process_data().futex_table.lock();
+        if Arc::strong_count(&self.inner) == 1 && self.inner.is_empty() {
+            table.0.remove(&self.key);
+        }
+    }
+}

--- a/core/src/futex.rs
+++ b/core/src/futex.rs
@@ -1,3 +1,5 @@
+//! Futex implementation.
+
 use core::ops::Deref;
 
 use alloc::{collections::btree_map::BTreeMap, sync::Arc};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,6 +8,7 @@
 extern crate axlog;
 extern crate alloc;
 
+pub mod futex;
 pub mod mm;
 pub mod task;
 mod time;

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -8,6 +8,7 @@ use core::{
 };
 
 use alloc::{
+    collections::btree_map::BTreeMap,
     string::String,
     sync::{Arc, Weak},
     vec::Vec,
@@ -207,6 +208,9 @@ pub struct ProcessData {
 
     /// The process signal manager
     pub signal: Arc<ProcessSignalManager<RawMutex, WaitQueueWrapper>>,
+
+    /// The futex table.
+    pub futex_table: Mutex<BTreeMap<usize, Arc<WaitQueue>>>,
 }
 
 impl ProcessData {
@@ -231,6 +235,8 @@ impl ProcessData {
                 signal_actions,
                 axconfig::plat::SIGNAL_TRAMPOLINE,
             )),
+
+            futex_table: Mutex::default(),
         }
     }
 

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -8,7 +8,6 @@ use core::{
 };
 
 use alloc::{
-    collections::btree_map::BTreeMap,
     string::String,
     sync::{Arc, Weak},
     vec::Vec,
@@ -31,7 +30,7 @@ use memory_addr::VirtAddrRange;
 use spin::{Once, RwLock};
 use weak_map::WeakMap;
 
-use crate::time::TimeStat;
+use crate::{futex::FutexTable, time::TimeStat};
 
 /// Create a new user task.
 pub fn new_user_task(
@@ -210,7 +209,7 @@ pub struct ProcessData {
     pub signal: Arc<ProcessSignalManager<RawMutex, WaitQueueWrapper>>,
 
     /// The futex table.
-    pub futex_table: Mutex<BTreeMap<usize, Arc<WaitQueue>>>,
+    pub futex_table: Mutex<FutexTable>,
 }
 
 impl ProcessData {

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -148,6 +148,14 @@ fn handle_syscall(tf: &mut TrapFrame, syscall_num: usize) -> isize {
             tf.arg4() as _,
         ),
         Sysno::sigaltstack => sys_sigaltstack(tf.arg0().into(), tf.arg1().into()),
+        Sysno::futex => sys_futex(
+            tf.arg0().into(),
+            tf.arg1() as _,
+            tf.arg2() as _,
+            tf.arg3().into(),
+            tf.arg4().into(),
+            tf.arg5() as _,
+        ),
         _ => {
             warn!("Unimplemented syscall: {}", sysno);
             Err(LinuxError::ENOSYS)


### PR DESCRIPTION
This PR implements basic futex functionalities (`FUTEX_WAIT`、`FUTEX_WAKE`、`FUTEX_REQUEUE`、`FUTEX_CMP_REQUEUE`) based on `axtask::WaitQueue`.

Also the behavior has specified in Linux manual is implemented

```
When a thread whose clear_child_tid is not NULL terminates, then,
if the thread is sharing memory with other threads, then 0 is
written at the address specified in clear_child_tid and the kernel
performs the following operation:
```