### PR TITLE
fix: execve

### DIFF
--- a/api/src/imp/task/execve.rs
+++ b/api/src/imp/task/execve.rs
@@ -2,13 +2,14 @@ use core::ffi::c_char;
 
 use alloc::{string::ToString, vec::Vec};
 use axerrno::{LinuxError, LinuxResult};
-use axhal::arch::UspaceContext;
+use axhal::arch::TrapFrame;
 use axtask::{TaskExtRef, current};
 use starry_core::mm::{load_user_app, map_trampoline};
 
 use crate::ptr::UserConstPtr;
 
 pub fn sys_execve(
+    tf: &mut TrapFrame,
     path: UserConstPtr<c_char>,
     argv: UserConstPtr<UserConstPtr<c_char>>,
     envp: UserConstPtr<UserConstPtr<c_char>>,
@@ -60,6 +61,7 @@ pub fn sys_execve(
 
     // TODO: fd close-on-exec
 
-    let uctx = UspaceContext::new(entry_point.as_usize(), user_stack_base, 0);
-    unsafe { uctx.enter_uspace(curr.kernel_stack_top().expect("No kernel stack top")) }
+    tf.set_ip(entry_point.as_usize());
+    tf.set_sp(user_stack_base.as_usize());
+    Ok(0)
 }

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -121,7 +121,7 @@ fn handle_syscall(tf: &mut TrapFrame, syscall_num: usize) -> isize {
         Sysno::nanosleep => sys_nanosleep(tf.arg0().into(), tf.arg1().into()),
 
         // task ops
-        Sysno::execve => sys_execve(tf.arg0().into(), tf.arg1().into(), tf.arg2().into()),
+        Sysno::execve => sys_execve(tf, tf.arg0().into(), tf.arg1().into(), tf.arg2().into()),
         Sysno::set_tid_address => sys_set_tid_address(tf.arg0()),
         #[cfg(target_arch = "x86_64")]
         Sysno::arch_prctl => sys_arch_prctl(tf, tf.arg0() as _, tf.arg1() as _),


### PR DESCRIPTION
Previously @eternalcomet reported a memory leak in the current `execve` implementation.

This PR fixes the issue by changing the implementation from re-entering userspace to modifying the current `TrapFrame`.
